### PR TITLE
docs: fix typo guide/components/async

### DIFF
--- a/src/guide/components/async.md
+++ b/src/guide/components/async.md
@@ -9,7 +9,7 @@ import { defineAsyncComponent } from 'vue'
 
 const AsyncComp = defineAsyncComponent(() => {
   return new Promise((resolve, reject) => {
-    // ...从服务区获取组件
+    // ...从服务器获取组件
     resolve(/* 获取到的组件 */)
   })
 })


### PR DESCRIPTION
## Description of Problem

fix typo `服务区` to `服务器`

## Proposed Solution

## Additional Information
