### PR TITLE
fix(attrs.md): improve consistency

### DIFF
--- a/src/guide/components/attrs.md
+++ b/src/guide/components/attrs.md
@@ -2,13 +2,13 @@
 outline: deep
 ---
 
-# 透传 attribute {#fallthrough-attributes}
+# 透传 Attribute {#fallthrough-attributes}
 
 > 阅读此章节时，我们假设你已经读过[组件基础](/guide/essentials/component-basics)，若你对组件还完全不了解，请先阅读它。
 
 ## Attribute 继承 {#attribute-inheritance}
 
-“透传 attribute”的意思是 attribute 或者被传递给一个组件的 `v-on` 事件监听器，但并没有显式地声明在所接收组件的 [props](./props) 或 [emits](./events.html#defining-custom-events) 上。最常见的例子就是 `class`、`style` 和 `id`。
+“透传 attribute”是传递给组件的 attribute 或者 `v-on` 事件监听器，但并没有显式地声明在所接收组件的 [props](./props) 或 [emits](./events.html#defining-custom-events) 上。最常见的例子就是 `class`、`style` 和 `id`。
 
 当一个组件以单个元素为根作渲染时，透传的 attribute 会自动添加到根元素的 attribute 中。举个例子，下面这个 `<MyButton>` 组件有这样的模板：
 
@@ -152,7 +152,7 @@ export default {
 <footer>...</footer>
 ```
 
-## 在 JavaScript 中访问透传 Attributes {#accessing-fallthrough-attributes-in-javascript}
+## 在 JavaScript 中访问透传 Attribute {#accessing-fallthrough-attributes-in-javascript}
 
 <div class="composition-api">
 


### PR DESCRIPTION
改动标题的依据如下：

- 译文中的**标题**大部分用的是 `Attribute`，即首字母大写，单数形式，我认为应该将标题全都统一到这种形式
- 译文的**正文**中均使用 `attribute`，没有一致性问题
- 根据[翻译须知](https://github.com/vuejs-translations/docs-zh-cn/wiki/%E7%BF%BB%E8%AF%91%E9%A1%BB%E7%9F%A5)，中文中夹杂的英文一律使用单数

改动正文中的那个句子的依据如下：

- 译文的语义错误，在原文中 `attribute` 和 `v-on event listener` 是并列关系，译文中这里翻译错了
