### PR TITLE
fix(reactivity-fundamentals.md): incorrect title when switching to co…

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -459,7 +459,7 @@ export default {
 
 这会渲染成这样：
 
-:::danger 这是一个用来展示 Error 弹框的示例
+:::danger This is an Error for Demo Purposes
 Something bad happened.
 :::
 
@@ -468,7 +468,7 @@ Something bad happened.
 ```vue{4}
 <template>
   <div class="alert-box">
-    <strong>Error!</strong>
+    <strong>This is an Error for Demo Purposes</strong>
     <slot />
   </div>
 </template>

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -302,7 +302,7 @@ function mutateDeeply() {
 
 <div class="composition-api">
 
-### 响应式代理 vs. 原始对象 {#reactive-proxy-vs-original} \*\*
+### 响应式代理 vs. 原始对象 \*\* {#reactive-proxy-vs-original-1} 
 
 值得注意的是，`reactive()` 返回的是一个原始对象的 [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)，它和原始对象是不相等的：
 

--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -218,7 +218,7 @@ export default {
 
 <div class="composition-api">
 
-有一个例外的情况，使用了 `<script setup>` 的组件时**默认私有**的：一个父组件无法访问到一个使用了 `<script setup>` 的子组件中的任何东西，除非子组件在其中通过 `defineExpose` 宏显式暴露：
+有一个例外的情况，使用了 `<script setup>` 的组件是**默认私有**的：一个父组件无法访问到一个使用了 `<script setup>` 的子组件中的任何东西，除非子组件在其中通过 `defineExpose` 宏显式暴露：
 
 ```vue
 <script setup>


### PR DESCRIPTION
…mposition API

## Description of Problem

你好！我今天在阅读中文文档时发现：选择组合式API时，有一个标题为**响应式代理 vs. 原始对象 {#reactive-proxy-vs-original}**，对比英文文档，我认为这是一个翻译错误。

具体请查看：

[响应式代理 vs. 原始对象 {#reactive-proxy-vs-original}](https://staging-cn.vuejs.org/guide/essentials/reactivity-fundamentals.html#%E5%93%8D%E5%BA%94%E5%BC%8F%E4%BB%A3%E7%90%86-vs-%E5%8E%9F%E5%A7%8B%E5%AF%B9%E8%B1%A1-reactive-proxy-vs-original)

## Proposed Solution

考虑到id的唯一性，我建议将对应的标题id从{#reactive-proxy-vs-original}改为{#reactive-proxy-vs-original-1}，该路径在英文文档是一样的。

## 一些后续

在阅读[组件模板——组件上的ref](https://staging-cn.vuejs.org/guide/essentials/template-refs.html#ref-on-component)这一部分，我发现了一个错别字：“使用了 <script setup> 的组件时默认私有的”。事实上，在英文文档中是“components using <script setup> are private by default”。因此，我建议将错别字更改过来，从”时“改为”是“。

另外，[组件基础——通过插槽来分配内容](https://staging-cn.vuejs.org/guide/essentials/component-basics.html#content-distribution-with-slots)中，代码示例的视图与源代码是不匹配的。其他页面除了注释部分进行翻译，都保持代码示例的视图与英文文档相同，并且与代码匹配。我认为应该保持与英文相同，这样代码示例的源码跟视图也是匹配的。
