### PR TITLE
Update template-syntax.md: Adjust translation details

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -34,9 +34,9 @@ Vue 使用一种基于 HTML 的模板语法，使我们能够声明式地将其�
   <p>Using v-html directive: <span v-html="rawHtml"></span></p>
 </p>
 
-这里我们遇到了一个新的概念。这里看到的 `v-html` attribute 被称为一个**指令**。指令由 `v-` 作为前缀，表明它们是一些由 Vue 提供的特殊 attribuite，你可能已经猜到了，它们将为渲染的 DOM 应用特殊的响应式行为。这里我们做的事情简单来说就是：在当前组件实例上，将此 span 元素的 innerHTML 与 `rawHtml` property 保持同步。
+这里我们遇到了一个新的概念。这里看到的 `v-html` attribute 被称为一个**指令**。指令由 `v-` 作为前缀，表明它们是一些由 Vue 提供的特殊 attribuite，你可能已经猜到了，它们将为渲染的 DOM 应用特殊的响应式行为。这里我们做的事情简单来说就是：在当前组件实例上，将此 `span` 元素的 innerHTML 与 `rawHtml` property 保持同步。
 
-`span` 的内容将会被替换为 `rawHtml` property 的值，插值为纯 HTML——数据绑定将会被忽略。注意，你不能使用 `v-html` 来拼接组合模板，因为 Vue 不是一个基于字符串的模板引擎。相反，组件应该作为 UI 重用和组合的基本单元。
+`span` 的内容将会被替换为 `rawHtml` property 的值，插值为纯 HTML——数据绑定将会被忽略。注意，你不能使用 `v-html` 来拼接组合模板，因为 Vue 不是一个基于字符串的模板引擎。相反，组件更适合作为 UI 重用和组合的基本单元。
 
 :::warning 安全警告
 在网站上动态渲染任意 HTML 是非常危险的，因为这非常容易造成 [XSS 漏洞](https://en.wikipedia.org/wiki/Cross-site_scripting)。请仅在内容安全可信时再使用 `v-html`，并且**永远不要**使用用户提供的 HTML 内容。


### PR DESCRIPTION
细节调整

## Description of Problem

<img width="752" alt="image" src="https://user-images.githubusercontent.com/10683193/164177784-aa8f6ef9-72fd-4112-a4d5-d4f354dcb9f0.png">

我注意到文档中有一处代码没有使用反引号包裹（见上图黄色方框）。

此外，下面有一句话（见上图红色方框）「应该」二字在这里读起来感觉很别扭，对照英文文档（见下图的红色方框）可以发现含义并没有完全对应上。

<img width="733" alt="image" src="https://user-images.githubusercontent.com/10683193/164178081-72020f1f-a8a2-4c5f-88aa-d0576cde8b3f.png">

## Proposed Solution

更新文档。

## Additional Information
