### PR TITLE
fix(api): display bug

### DIFF
--- a/src/api/ApiIndex.vue
+++ b/src/api/ApiIndex.vue
@@ -31,7 +31,9 @@ const filtered = computed(() => {
             return item
           }
           // filter headers
-          const matchedHeaders = item.headers.filter(matches)
+          const matchedHeaders = item.headers
+            .map((h) => h.text)
+            .filter(matches)
           return matchedHeaders.length
             ? { text: item.text, link: item.link, headers: matchedHeaders }
             : null
@@ -93,7 +95,9 @@ function slugify(text: string): string {
           <h3>{{ item.text }}</h3>
           <ul>
             <li v-for="h of item.headers" :key="h">
-              <a :href="item.link + '.html#' + slugify(h)">{{ h }}</a>
+              <a :href="item.link + '.html#' + slugify(h.anchor)">
+                {{ h.text }}
+              </a>
             </li>
           </ul>
         </div>

--- a/src/api/api.data.ts
+++ b/src/api/api.data.ts
@@ -58,16 +58,17 @@ function parsePageHeaders(link: string) {
   const h2s = src.match(/^## [^\n]+/gm)
   let headers: { anchor: string; text: string }[] = []
   if (h2s) {
-    headers = h2s.map((h) => ({
-      anchor: h.match(/\{#([a-zA-Z0-9-]+)\}/)?.[1] ?? '',
-      text: h
+    headers = h2s.map((h) => {
+      let text = h
         .slice(2)
         .replace(/<sup class=.*/, '')
         .replace(/\\</g, '<')
         .replace(/`([^`]+)`/g, '$1')
         .replace(/\{#([a-zA-Z0-9-]+)\}/g, '') // hidden anchor tag
         .trim()
-    }))
+      let anchor = h.match(/\{#([a-zA-Z0-9-]+)\}/)?.[1] ?? text
+      return { text, anchor }
+    })
   }
   headersCache.set(fullPath, {
     timestamp,

--- a/src/api/api.data.ts
+++ b/src/api/api.data.ts
@@ -9,7 +9,10 @@ export interface APIGroup {
   items: {
     text: string
     link: string
-    headers: string[]
+    headers: {
+      anchor: string
+      text: string
+    }[]
   }[]
 }
 
@@ -34,7 +37,10 @@ export default {
 const headersCache = new Map<
   string,
   {
-    headers: string[]
+    headers: {
+      anchor: string
+      text: string
+    }[]
     timestamp: number
   }
 >()
@@ -50,17 +56,18 @@ function parsePageHeaders(link: string) {
 
   const src = fs.readFileSync(fullPath, 'utf-8')
   const h2s = src.match(/^## [^\n]+/gm)
-  let headers: string[] = []
+  let headers: { anchor: string; text: string }[] = []
   if (h2s) {
-    headers = h2s.map((h) =>
-      h
+    headers = h2s.map((h) => ({
+      anchor: h.match(/\{#([a-zA-Z0-9-]+)\}/)?.[1] ?? '',
+      text: h
         .slice(2)
         .replace(/<sup class=.*/, '')
         .replace(/\\</g, '<')
         .replace(/`([^`]+)`/g, '$1')
-        .replace(/\{#([a-zA-Z0-9]+)\}/g, '') // hidden anchor tag
+        .replace(/\{#([a-zA-Z0-9-]+)\}/g, '') // hidden anchor tag
         .trim()
-    )
+    }))
   }
   headersCache.set(fullPath, {
     timestamp,


### PR DESCRIPTION
## Description of Problem

例如下图，当前中文api文档页面的显示和跳转都会出现问题：
![image](https://user-images.githubusercontent.com/55696968/164467366-350ec14b-b842-4467-8154-f843944165fa.png)

## Proposed Solution

这个PR修改了`api.data.ts`中的`headers`类型，并加上了对于`anchor`的特殊处理
