### PR TITLE
fix(guide): type augmentation placement

### DIFF
--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -232,7 +232,7 @@ declare module 'vue' {
 
 ### 类型扩充的位置 {#type-augmentation-placement}
 
-我们可以将这些类型扩充放在一个 `.ts` 文件，或是一个以整个项目为范围的 `*.d.ts` 文件中。无论哪一种，确保在 `tsconfig.json` 中将其引入。对于库或插件作者，这个文件应该在 `package.json` 的 `type` property 中被列出。
+我们可以将这些类型扩充放在一个 `.ts` 文件，或是一个以整个项目为范围的 `*.d.ts` 文件中。无论哪一种，确保在 `tsconfig.json` 中将其引入。对于库或插件作者，这个文件应该在 `package.json` 的 `types` property 中被列出。
 
 为了利用模块扩充的优势，你需要确保将扩充的模块放在 [TypeScript 模块](https://www.typescriptlang.org/docs/handbook/modules.html) 中。 也就是说，该文件需要包含至少一个顶级的 `import` 或 `export`，即使它只是 `export {}`。如果扩充被放在模块之外，它将覆盖原始类型，而不是扩充!
 


### PR DESCRIPTION
## Description of Problem
中文文档勘误，`package.json` 中 `TypeScript` 声明文件对应字段应为 `types`，英文文档无误，应该是翻译时疏漏了
## Proposed Solution
`type` -> `types`
## Additional Information
