### PR TITLE
fix the hydrate translation

### DIFF
--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -234,7 +234,7 @@ export function register() {
 
 - 一个响应式状态管理系统，促进跨组件逻辑提取和重用；
 
-- 一种在服务器上呈现组件并在客户端“激活” (hydrate)组件的高性能方法 (SSR)，这对 SEO 和 [LCP 这样的 Web 关键指标](https://web.dev/vitals/)非常重要。原生自定义元素 SSR 通常需要在 Node.js 中模拟 DOM，然后序列化更改后的 DOM，而 Vue SSR 则尽可能地将其编译为拼接起来的字符串，这会高效得多。
+- 一种在服务器上呈现组件并在客户端“激活” (hydrate) 组件的高性能方法 (SSR)，这对 SEO 和 [LCP 这样的 Web 关键指标](https://web.dev/vitals/)非常重要。原生自定义元素 SSR 通常需要在 Node.js 中模拟 DOM，然后序列化更改后的 DOM，而 Vue SSR 则尽可能地将其编译为拼接起来的字符串，这会高效得多。
 
 Vue 的组件模型在设计时考虑到这些需求，将其作为一个更聚合的系统。
 

--- a/src/guide/extras/web-components.md
+++ b/src/guide/extras/web-components.md
@@ -234,7 +234,7 @@ export function register() {
 
 - 一个响应式状态管理系统，促进跨组件逻辑提取和重用；
 
-- 一种在服务器上呈现组件并在客户端水合组件的高性能方法 (SSR)，这对 SEO 和 [LCP 这样的 Web 关键指标](https://web.dev/vitals/)非常重要。原生自定义元素 SSR 通常需要在 Node.js 中模拟 DOM，然后序列化更改后的 DOM，而 Vue SSR 则尽可能地将其编译为拼接起来的字符串，这会高效得多。
+- 一种在服务器上呈现组件并在客户端“激活” (hydrate)组件的高性能方法 (SSR)，这对 SEO 和 [LCP 这样的 Web 关键指标](https://web.dev/vitals/)非常重要。原生自定义元素 SSR 通常需要在 Node.js 中模拟 DOM，然后序列化更改后的 DOM，而 Vue SSR 则尽可能地将其编译为拼接起来的字符串，这会高效得多。
 
 Vue 的组件模型在设计时考虑到这些需求，将其作为一个更聚合的系统。
 


### PR DESCRIPTION
## Description of Problem
English docs
![image](https://user-images.githubusercontent.com/72451061/167799632-6a169ca4-457a-4d7e-8901-4b68b358f94c.png)
![image](https://user-images.githubusercontent.com/72451061/167799750-cf7cd780-dc50-4604-a6e9-4a0fbcbec2e3.png)
hydrate 翻译问题
## Proposed Solution
根据https://github.com/vuejs/docs-next-zh-cn/pull/786
应该将水合修改为“激活” (hydrate)
## Additional Information
