### PR TITLE
fix: 纠正单词错误

### DIFF
--- a/src/guide/extras/reactivity-transform.md
+++ b/src/guide/extras/reactivity-transform.md
@@ -287,7 +287,7 @@ Vue 为这些宏函数都提供了类型声明 (全局可用) 并且类型都会
 
 - 需要 `@vitejs/plugin-vue@^2.0.0`
 - 应用于 SFC 和 js(x)/ts(x) 文件。在执行转换之前，会对文件进行快速的使用检查，因此不使用宏的文件应该不会有性能损失。
-- 注意 `refTransform` 现在是一个插件的顶层选项，而不再是位于 `script.refSugar` 之中了，因为它不仅仅只对 SFC 起效。
+- 注意 `reactivityTransform` 现在是一个插件的顶层选项，而不再是位于 `script.refSugar` 之中了，因为它不仅仅只对 SFC 起效。
 
 ```js
 // vite.config.js


### PR DESCRIPTION
结合上下文的内容，同时对比了英文版本的文档，`refTransform` 目前应该是  `reactivityTransform`
