### PR TITLE
fix(template-syntax): change 'other falsy' translation

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -61,7 +61,7 @@ export default {
 }
 ```
 
-当你在赋值后再访问 `this.someObject`，此值已经是原来的 `newObject` 的一个响应式代理。**这与 Vue 2 中原始的 `newObject` 不会变为响应式完全不同：请确保始终通过 `this` 来访问响应式状态。**
+当你在赋值后再访问 `this.someObject`，此值已经是原来的 `newObject` 的一个响应式代理。**与 Vue 2 不同的是，这里原始的 `newObject` 不会变为响应式：请确保始终通过 `this` 来访问响应式状态。**
 
 </div>
 

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -74,7 +74,7 @@ Vue 使用一种基于 HTML 的模板语法，使我们能够声明式地将其�
 <button :disabled="isButtonDisabled">Button</button>
 ```
 
-当 `isButtonDisabled` 为[真值](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)或一个空字符串 (即 `<button disabled="">`) 时，元素会包含这个 `disabled` attribute。而当其为[假值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)时 attribute 将被忽略。
+当 `isButtonDisabled` 为[真值](https://developer.mozilla.org/en-US/docs/Glossary/Truthy)或一个空字符串 (即 `<button disabled="">`) 时，元素会包含这个 `disabled` attribute。而当其为其他[假值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)时 attribute 将被忽略。
 
 ### 动态绑定多个值 {#dynamically-binding-multiple-attributes}
 


### PR DESCRIPTION
## Description of Problem
### 问题 1
英文原文为 "For other [falsy values](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) the attribute will be omitted."。`other falsy values` 翻译错误

### 问题 2
原文 "Unlike in Vue 2, the original newObject is left intact and will not be made reactive:" 翻译错误
## Proposed Solution

### 回答 1
`other falsy values` 目前翻译为`假值`，应该翻译为 `其他假值`。

### 回答 2
翻译为 "与 Vue 2 不同的是，这里原始的 `newObject` 不会变为响应式" 更为恰当
## Additional Information
