### PR TITLE
docs: remove redundant text

### DIFF
--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -5,7 +5,7 @@ footer: false
 # 简介 {#introduction}
 
 :::info 你正在阅读的是 Vue 3 的文档！
-- Vue 2 中文文档已被迁移至 [v2.cn.vuejs.org](https://v2.cn.vuejs.org/)。
+- Vue 2 中文文档已迁移至 [v2.cn.vuejs.org](https://v2.cn.vuejs.org/)。
 - 想从 Vue 2 升级？请参考[迁移指南](https://v3-migration.vuejs.org/)。
 :::
 


### PR DESCRIPTION
## Description of Problem
原翻译：“Vue 2 中文文档已被迁移至”，其中“被”字多余，改为“Vue 2 中文文档已迁移至”更加清爽
## Proposed Solution
删除“被”字
