### PR TITLE
change ecosystem links to official translations

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -48,10 +48,11 @@ const nav = [
         ]
       },
       {
-        text: '核心库',
+        text: '官方库',
         items: [
           { text: 'Vue Router', link: 'https://router.vuejs.org/' },
-          { text: 'Pinia', link: 'https://pinia.vuejs.org/' }
+          { text: 'Pinia', link: 'https://pinia.vuejs.org/' },
+          { text: '工具链指南', link: '/guide/scaling-up/tooling.html' }
         ]
       },
       {
@@ -595,7 +596,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   scrollOffset: 'header',
 
   head: [
-    ['meta', { name: 'theme-color', content: "#3c8772" }],
+    ['meta', { name: 'theme-color', content: '#3c8772' }],
     ['meta', { name: 'twitter:site', content: '@vuejs' }],
     ['meta', { name: 'twitter:card', content: 'summary' }],
     [

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -50,7 +50,7 @@ const nav = [
       {
         text: '官方库',
         items: [
-          { text: 'Vue Router', link: 'https://router.vuejs.org/' },
+          { text: 'Vue Router', link: 'https://router.vuejs.org/zh/' },
           { text: 'Pinia', link: 'https://pinia.vuejs.org/' },
           { text: '工具链指南', link: '/guide/scaling-up/tooling.html' }
         ]
@@ -104,7 +104,7 @@ const nav = [
         text: '社区指南',
         link: '/about/community-guide'
       },
-      { text: '行为准则', link: 'https://vuejs.org/about/coc.html' },
+      { text: '行为规范', link: 'https://vuejs.org/about/coc.html' },
       {
         text: '纪录片',
         link: 'https://www.youtube.com/watch?v=OrxmtDw4pVI'

--- a/src/api/application.md
+++ b/src/api/application.md
@@ -400,7 +400,7 @@ console.log(app.config)
 ::: warning 重要
 此配置项仅在完整构建版本，即可以在浏览器中编译模板的 `vue.js` 文件中可用。如果你用的是带构建的项目配置，且使用的是仅含运行时的 Vue 文件版本，那么编译器选项必须通过构建工具的相关配置传递给 `@vue/compiler-dom`。
 
-- `vue-loader`：[通过 `compilerOptions` loader 的选项传递](https://vue-loader.vuejs.org/options.html#compileroptions)。并请阅读[如何在 `vue-cli` 中配置它](https://cli.vuejs.org/guide/webpack.html#modifying-options-of-a-loader)。
+- `vue-loader`：[通过 `compilerOptions` loader 的选项传递](https://vue-loader.vuejs.org/zh/options.html#compileroptions)。并请阅读[如何在 `vue-cli` 中配置它](https://cli.vuejs.org/zh/guide/webpack.html#%E4%BF%AE%E6%94%B9-loader-%E9%80%89%E9%A1%B9)。
 
 - `vite`：[通过 `@vitejs/plugin-vue` 的选项传递](https://github.com/vitejs/vite/tree/main/packages/plugin-vue#options)。
 :::

--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -105,9 +105,9 @@ p {{ msg }}
 
 注意对不同预处理器的集成会根据你所使用的工具链而有所不同，具体细节请查看相应的工具链文档来确认：
 
-- [Vite](https://vitejs.dev/guide/features.html#css-pre-processors)
-- [Vue CLI](https://cli.vuejs.org/guide/css.html#pre-processors)
-- [webpack + vue-loader](https://vue-loader.vuejs.org/guide/pre-processors.html#using-pre-processors)
+- [Vite](https://cn.vitejs.dev/guide/features.html#css-pre-processors)
+- [Vue CLI](https://cli.vuejs.org/zh/guide/css.html#%E9%A2%84%E5%A4%84%E7%90%86%E5%99%A8)
+- [webpack + vue-loader](https://vue-loader.vuejs.org/zh/guide/pre-processors.html#%E4%BD%BF%E7%94%A8%E9%A2%84%E5%A4%84%E7%90%86%E5%99%A8)
 
 ## Src 导入 {#src-imports}
 

--- a/src/api/ssr.md
+++ b/src/api/ssr.md
@@ -213,7 +213,7 @@
   import { useSSRContext } from 'vue'
 
   // 确保只在服务端渲染时调用
-  // https://vitejs.dev/guide/ssr.html#conditional-logic
+  // https://cn.vitejs.dev/guide/ssr.html#conditional-logic
   if (import.meta.env.SSR) {
     const ctx = useSSRContext()
     // ...给上下文对象添加属性

--- a/src/guide/best-practices/production-deployment.md
+++ b/src/guide/best-practices/production-deployment.md
@@ -32,9 +32,9 @@
 
 其他参考：
 
-- [Vite 生产环境指南](https://vitejs.dev/guide/build.html)
-- [Vite 部署指南](https://vitejs.dev/guide/static-deploy.html)
-- [Vue CLI 部署指南](https://cli.vuejs.org/guide/deployment.html)
+- [Vite 生产环境指南](https://cn.vitejs.dev/guide/build.html)
+- [Vite 部署指南](https://cn.vitejs.dev/guide/static-deploy.html)
+- [Vue CLI 部署指南](https://cli.vuejs.org/zh/guide/deployment.html)
 
 ## 追踪运行时错误 {#tracking-runtime-errors}
 

--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -107,7 +107,7 @@ const posts = await res.json()
 
 我们常常会将 `<Suspense>` 和 [`<Transition>`](./transition)、[`<KeepAlive>`](./keep-alive) 等组件结合。要保证这些组件都能正常工作，嵌套的顺序非常重要。
 
-另外，这些组件都通常与 [Vue Router](https://next.router.vuejs.org/) 中的 `<RouterView>` 组件结合使用。
+另外，这些组件都通常与 [Vue Router](https://router.vuejs.org/zh/) 中的 `<RouterView>` 组件结合使用。
 
 下面的示例展示了如何嵌套这些组件，使它们都能按照预期的方式运行。若想组合得更简单，你也可以删除一些你不需要的组件：
 
@@ -131,4 +131,4 @@ const posts = await res.json()
 </RouterView>
 ```
 
-Vue Router 使用动态导入对[懒加载组件](https://next.router.vuejs.org/guide/advanced/lazy-loading.html)进行了内置支持。这些与异步组件不同，目前他们不会触发 `<Suspense>`。但是，它们仍然可以有异步组件作为后代，这些组件可以照常触发 `<Suspense>`。
+Vue Router 使用动态导入对[懒加载组件](https://router.vuejs.org/zh/guide/advanced/lazy-loading.html)进行了内置支持。这些与异步组件不同，目前他们不会触发 `<Suspense>`。但是，它们仍然可以有异步组件作为后代，这些组件可以照常触发 `<Suspense>`。

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -51,7 +51,7 @@ footer: false
 你现在应该已经运行起来了你的第一个 Vue 项目！请注意，生成的项目中的示例组件是使用[组合式 API](/guide/introduction.html#composition-api) 和 `<script setup>` 编写的，而非[选项式 API](/guide/introduction.html#options-api)。下面是一些补充提示：
 
 - 推荐的 IDE 配置是 [Visual Studio Code](https://code.visualstudio.com/) + [Volar 扩展](https://marketplace.visualstudio.com/items?itemName=Vue.volar)。如果使用其他编辑器，参考 [IDE 支持章节](/guide/scaling-up/tooling.html#ide-support)。
-- 更多工具细节，包括与后端框架的整合，我们会在[工具链指引](/guide/scaling-up/tooling.html)进行讨论。
+- 更多工具细节，包括与后端框架的整合，我们会在[工具链指南](/guide/scaling-up/tooling.html)进行讨论。
 - 要了解构建工具 Vite 更多背后的细节，请查看 [Vite 文档](https://cn.vitejs.dev)。
 - 如果你选择使用 TypeScript，请阅读 [TypeScript 使用指南](typescript/overview.html)。
 

--- a/src/guide/scaling-up/routing.md
+++ b/src/guide/scaling-up/routing.md
@@ -17,7 +17,7 @@
   </VueSchoolLink>
 </div>
 
-Vue 很适合用来构建单页面应用。对于大多数此类应用，都推荐使用官方支持的[路由库](https://github.com/vuejs/router)。要了解更多细节，请查看 [Vue Router 的文档](https://router.vuejs.org/zh/index.html)。
+Vue 很适合用来构建单页面应用。对于大多数此类应用，都推荐使用官方支持的[路由库](https://github.com/vuejs/router)。要了解更多细节，请查看 [Vue Router 的文档](https://router.vuejs.org/zh/)。
 
 ## 从头开始实现一个简单的路由 {#simple-routing-from-scratch}
 

--- a/src/guide/scaling-up/sfc.md
+++ b/src/guide/scaling-up/sfc.md
@@ -68,7 +68,7 @@ SFC 中的 `<style>` 标签一般会在开发时注入成原生的 `<style>` 标
 
 你可以在 [Vue SFC 演练场](https://sfc.vuejs.org/)中实际使用一下单文件组件，同时可以看到它们最终被编译后的样子。
 
-在实际项目中，我们一般会使用集成了 SFC 编译器的构建工具，比如 [Vite](https://vitejs.dev/) 或者 [Vue CLI](http://cli.vuejs.org/) (基于 [webpack](https://webpack.js.org/))，Vue 官方也提供了脚手架工具来帮助你尽可能快速地上手开发 SFC。更多细节请查看 [SFC 工具链](/guide/scaling-up/tooling)章节。
+在实际项目中，我们一般会使用集成了 SFC 编译器的构建工具，比如 [Vite](https://cn.vitejs.dev/) 或者 [Vue CLI](https://cli.vuejs.org/zh/) (基于 [webpack](https://webpack.js.org/))，Vue 官方也提供了脚手架工具来帮助你尽可能快速地上手开发 SFC。更多细节请查看 [SFC 工具链](/guide/scaling-up/tooling)章节。
 
 ## 如何看待关注点分离？ {#what-about-separation-of-concerns}
 

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -229,7 +229,7 @@ server.get('/', (req, res) => {
 
 ### Vite SSR {#vite-ssr}
 
-Vite 提供了内置的 [Vue 服务端渲染支持](https://vitejs.dev/guide/ssr.html)，但它在设计上是偏底层的。如果你想要直接使用 Vite，可以看看 [vite-plugin-ssr](https://vite-plugin-ssr.com/)，一个帮你抽象掉许多复杂细节的社区插件。
+Vite 提供了内置的 [Vue 服务端渲染支持](https://cn.vitejs.dev/guide/ssr.html)，但它在设计上是偏底层的。如果你想要直接使用 Vite，可以看看 [vite-plugin-ssr](https://vite-plugin-ssr.com/)，一个帮你抽象掉许多复杂细节的社区插件。
 
 你也可以在[这里](https://github.com/vitejs/vite/tree/main/playground/ssr-vue)查看一个使用手动配置的 Vue + Vite SSR 的示例项目，以它作为基础来构建。请注意，这种方式只有在你有丰富的 SSR 和构建工具经验，并希望对应用的架构做深入的定制时才推荐使用。
 

--- a/src/guide/scaling-up/state-management.md
+++ b/src/guide/scaling-up/state-management.md
@@ -236,7 +236,7 @@ export function useCount() {
 
 [Pinia](https://pinia.vuejs.org) 就是一个实现了上述需求的状态管理库，由 Vue 核心团队维护，对 Vue 2 和 Vue 3 都可用。
 
-现有用户可能对 [Vuex](https://vuex.vuejs.org/) 更熟悉，它是 Vue 之前的官方状态管理库。由于 Pinia 在生态系统中能够承担相同的职责且能做得更好，因此 Vuex 现在处于维护模式。它仍然可以工作，但不再接受新的功能。对于新的应用，建议使用 Pinia。
+现有用户可能对 [Vuex](https://vuex.vuejs.org/zh/) 更熟悉，它是 Vue 之前的官方状态管理库。由于 Pinia 在生态系统中能够承担相同的职责且能做得更好，因此 Vuex 现在处于维护模式。它仍然可以工作，但不再接受新的功能。对于新的应用，建议使用 Pinia。
 
 事实上，Pinia 最初正是为了探索 Vuex 的下一个版本而开发的，因此整合了核心团队关于 Vuex 5 的许多想法。最终，我们意识到 Pinia 已经实现了我们想要在 Vuex 5 中提供的大部分内容，因此决定将其作为新的官方推荐。
 

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -101,7 +101,7 @@ describe('increment', () => {
 
 - [Vitest](https://vitest.dev/)
 
-  因为由 `create-vue` 创建的官方项目配置是基于 [Vite](https://vitejs.dev/) 的，所以我们推荐你使用一个可以利用同一套 Vite 配置和转换管道的单元测试框架。[Vitest](https://vitest.dev/) 正是一个针对此目标设计的单元测试框架，它由 Vue / Vite 团队成员开发和维护。在 Vite 的项目集成它会非常简单，而且速度非常快。
+  因为由 `create-vue` 创建的官方项目配置是基于 [Vite](https://cn.vitejs.dev/) 的，所以我们推荐你使用一个可以利用同一套 Vite 配置和转换管道的单元测试框架。[Vitest](https://cn.vitest.dev/) 正是一个针对此目标设计的单元测试框架，它由 Vue / Vite 团队成员开发和维护。在 Vite 的项目集成它会非常简单，而且速度非常快。
 
 ### 其他选择 {#other-options}
 

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -17,7 +17,7 @@
 
 ### Vite {#vite}
 
-[Vite](https://vitejs.dev/) 是一个轻量级的、速度极快的构建工具，对 Vue SFC 提供第一优先级支持。作者是尤雨溪，同时也是 Vue 的作者！
+[Vite](https://cn.vitejs.dev/) 是一个轻量级的、速度极快的构建工具，对 Vue SFC 提供第一优先级支持。作者是尤雨溪，同时也是 Vue 的作者！
 
 要使用 Vite 来创建一个 Vue 项目，非常简单：
 
@@ -32,7 +32,7 @@
 
 ### Vue CLI {#vue-cli}
 
-[Vue CLI](https://cli.vuejs.org/) 是官方提供的基于 Webpack 的 Vue 工具链，它现在处于维护模式。我们建议使用 Vite 开始新的项目，除非你依赖特定的 Webpack 的特性。在大多数情况下，Vite 将提供更优秀的开发体验。
+[Vue CLI](https://cli.vuejs.org/zh/) 是官方提供的基于 Webpack 的 Vue 工具链，它现在处于维护模式。我们建议使用 Vite 开始新的项目，除非你依赖特定的 Webpack 的特性。在大多数情况下，Vite 将提供更优秀的开发体验。
 
 关于从 Vue CLI 迁移到 Vite 的资源：
 
@@ -150,9 +150,9 @@ Vue 团队维护着 [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-v
 
 ### `vue-loader` {#vue-loader}
 
-- [文档](https://vue-loader.vuejs.org/)
+- [文档](https://vue-loader.vuejs.org/zh/)
 
-为 webpack 提供 Vue SFC 支持的官方 loader。如果你正在使用 Vue CLI，也可以看看[如何在 Vue CLI 中更改 `vue-loader` 选项的文档](https://cli.vuejs.org/guide/webpack.html#modifying-options-of-a-loader)。
+为 webpack 提供 Vue SFC 支持的官方 loader。如果你正在使用 Vue CLI，也可以看看[如何在 Vue CLI 中更改 `vue-loader` 选项的文档](https://cli.vuejs.org/zh/guide/webpack.html#%E4%BF%AE%E6%94%B9-loader-%E9%80%89%E9%A1%B9)。
 
 ## 其他在线演练场 {#other-online-playgrounds}
 

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -10,7 +10,7 @@ Vue 本身就是用 TypeScript 编写的，并对 TypeScript 提供了一等公�
 
 ## 项目配置 {#project-setup}
 
-[`create-vue`](https://github.com/vuejs/create-vue)，即官方的项目脚手架工具，提供了搭建基于 [Vite](https://vitejs.dev/) 且 TypeScript 就绪的 Vue 项目的选项。
+[`create-vue`](https://github.com/vuejs/create-vue)，即官方的项目脚手架工具，提供了搭建基于 [Vite](https://cn.vitejs.dev/) 且 TypeScript 就绪的 Vue 项目的选项。
 
 ### 总览 {#overview}
 


### PR DESCRIPTION
- Code of Conduct 翻译为“行为规范”
- 根据 https://github.com/vuejs/docs/commit/ebab2325755f3c6e29cf0b13b32f7d2936593cc6 更新生态系统菜单的翻译
- 对于 Vite、Vue CLI、Vue Router、Vuex、Vue Loader 等存在官方中文文档的生态库，替换链接至中文翻译