### PR TITLE
fix: force double quotes to be rendered with Chinese fonts

### DIFF
--- a/.vitepress/theme/styles/fonts.css
+++ b/.vitepress/theme/styles/fonts.css
@@ -1,0 +1,12 @@
+@font-face {
+  font-family: Quotes;
+  src: local('PingFang SC Regular'), local('PingFang SC'),
+    local('Microsoft YaHei'), local('Source Han Sans SC');
+  unicode-range: U+201C, U+201D;
+}
+
+body {
+  --vt-font-family-base: Quotes, Inter, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', sans-serif;
+}

--- a/.vitepress/theme/styles/fonts.css
+++ b/.vitepress/theme/styles/fonts.css
@@ -1,8 +1,9 @@
+/* 中英文弯引号共享 Unicode 码位，确保引号使用中文字体渲染 */
 @font-face {
   font-family: Quotes;
   src: local('PingFang SC Regular'), local('PingFang SC'),
     local('Microsoft YaHei'), local('Source Han Sans SC');
-  unicode-range: U+201C, U+201D;
+  unicode-range: U+2018, U+2019, U+201C, U+201D; /* 分别是 ‘’“” */
 }
 
 body {

--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -1,4 +1,4 @@
-@import "./fonts.css";
+@import "./quotes.css";
 @import "./pages.css";
 @import "./badges.css";
 @import "./options-boxes.css";

--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -1,3 +1,4 @@
+@import "./fonts.css";
 @import "./pages.css";
 @import "./badges.css";
 @import "./options-boxes.css";

--- a/.vitepress/theme/styles/quotes.css
+++ b/.vitepress/theme/styles/quotes.css
@@ -1,8 +1,8 @@
 /* 中英文弯引号共享 Unicode 码位，确保引号使用中文字体渲染 */
 @font-face {
   font-family: Quotes;
-  src: local('PingFang SC Regular'), local('PingFang SC'),
-    local('Microsoft YaHei'), local('Source Han Sans SC');
+  src: local('PingFang SC Regular'), local('PingFang SC'), local('SimHei'),
+    local('Source Han Sans SC');
   unicode-range: U+2018, U+2019, U+201C, U+201D; /* 分别是 ‘’“” */
 }
 

--- a/.vitepress/theme/styles/quotes.css
+++ b/.vitepress/theme/styles/quotes.css
@@ -11,3 +11,14 @@ body {
     'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
 }
+
+/**
+ * 不用 --vt-font-family-base 因为如果元素本身没有设置 font-family，会继承外部的 font-family，
+ * 在这里设置 --vt-font-family-base 是无效的。不用 :lang(en) 因为这样可以把 font-family 设置范
+ * 围控制得小一点。
+ */
+[lang|='en'] {
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+}


### PR DESCRIPTION
## Description of Problem

见 #530 

## Proposed Solution

用指向本地文件的 `@font-face` 来把双引号强制使用中文字体渲染。

## Additional Information

[效果预览](https://cn-vuejs-org-git-fork-justineo-fix-quotes-vuejs.vercel.app/guide/introduction.html#what-is-vue:~:text=%E7%81%B5%E6%B4%BB%E6%80%A7%E5%92%8C-,%E2%80%9C%E5%8F%AF%E4%BB%A5%E8%A2%AB%E9%80%90%E6%AD%A5%E9%9B%86%E6%88%90%E2%80%9D,-%E8%BF%99%E4%B8%AA%E7%89%B9%E7%82%B9%E3%80%82%E6%A0%B9%E6%8D%AE)

#### Before

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1726061/188454627-cbc84dd3-90bf-4a81-944d-4793bb11895c.png">

#### After

<img width="714" alt="image" src="https://user-images.githubusercontent.com/1726061/188454495-4aeed661-eb1e-4422-8887-019c732c4a5a.png">
