### PR TITLE
fix: italic problem

### DIFF
--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -1,4 +1,4 @@
-@import "./quotes.css";
+@import "./zh-cn.css";
 @import "./pages.css";
 @import "./badges.css";
 @import "./options-boxes.css";

--- a/.vitepress/theme/styles/zh-cn.css
+++ b/.vitepress/theme/styles/zh-cn.css
@@ -10,6 +10,10 @@ body {
   --vt-font-family-base: Quotes, Inter, -apple-system, BlinkMacSystemFont,
     'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
+  /**
+   * 修复斜体不生效
+   */
+  text-rendering: unset !important;
 }
 
 /**


### PR DESCRIPTION
## Description of Problem

起因：目前的文档，即使 HTML 已经渲染了 em 标签，对于中文文本来说依然不能得到斜体效果。

see https://github.com/vuejs-translations/docs-zh-cn/pull/556#issuecomment-1266190590

备注：我在本地测试时（windows 10），删除该属性只能偶尔生效，chrome/edge 均如此。暂未定位到具体原因。

建议大家查看 https://deploy-preview-571--vue-docs-zh-cn.netlify.app/guide/quick-start.html 以确认该改动是否有效：

```
<p>上面的例子使用了<em>全局构建版本</em>的 Vue
```