### PR TITLE
fix: typo v-bind CSS

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -130,7 +130,7 @@
   :::
 
 :::info 参考
-SFC `<style>` 标签支持通过 `v-bind:CSS` 函数来链接 CSS 值与组件状态。这允许在没有类型扩展的情况下自定义属性。
+SFC `<style>` 标签支持通过 `v-bind` CSS 函数来链接 CSS 值与组件状态。这允许在没有类型扩展的情况下自定义属性。
 
 - [CSS 中的 v-bind()](/api/sfc-css-features.html#v-bind-in-css)
   :::


### PR DESCRIPTION
## Description of Problem

`v-bind:CSS` update `v-bind` CSS

sync vuejs/docs@72b203380bda37f83cbcf31805f969d67b7b0214
