### PR TITLE
Update forms.md

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -52,7 +52,7 @@ const multiSelected = ref([])
 ### 文本 {#text}
 
 ```vue-html
-<p>Message is: {{ message }}</p>
+<p style="word-break:break-word;">Message is: {{ message }}</p>
 <input v-model="message" placeholder="edit me" />
 ```
 
@@ -87,7 +87,7 @@ const multiSelected = ref([])
 
 <div class="demo">
   <span>Multiline message is:</span>
-  <p style="white-space: pre-line;">{{ multilineText }}</p>
+  <p style="white-space: pre-line; word-break:break-word;">{{ multilineText }}</p>
   <textarea v-model="multilineText" placeholder="add multiple lines"></textarea>
 </div>
 


### PR DESCRIPTION
 When I was reading the documentation, I found that the content input in the text box of the demo module will overflow the demo box with the < p > tag above. I don't know if this is a potential bug, so I added an automatic line wrapping property to it to try to fix it

## Description of Problem
When I tried to input the content of the < input > tag and the < textarea > tag in the demo section of "multi-line text" and "single-line text", I found that the content of the < p > tag above would overflow the demo module. I don't know if this is a bug. I tried to add the CSS property of'word-break: break-word; 'to these < p > tags to make them wrap automatically
![image](https://user-images.githubusercontent.com/80050599/201464731-b1f256a2-fef9-48ea-8083-e66b0cc81e38.png)

## Proposed Solution
I added the word-break: break-word; attribute to the < p > tag to make it wrap automatically, so that the content of the < p > tag will not overflow outside the demo box
![image](https://user-images.githubusercontent.com/80050599/201464891-bf95e5c0-4a82-45d2-88a5-03cf61344582.png)


## Additional Information
