### PR TITLE
Configuring Ecosystem Internationalization Fields

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -555,6 +555,7 @@ const i18n: ThemeConfig['i18n'] = {
   search: '搜索',
   menu: '菜单',
   toc: '本页目录',
+  ecosystem:'生态系统',
   returnToTop: '返回顶部',
   appearance: '外观',
   previous: '前一篇',

--- a/.vitepress/theme/components/SiteMap.vue
+++ b/.vitepress/theme/components/SiteMap.vue
@@ -4,10 +4,10 @@ import { useData } from 'vitepress'
 
 const data = useData()
 const nav = data.site.value.themeConfig.nav
-const ecosystem = nav.find((i: any) => i.text === 'Ecosystem')
-const items = nav
-  .filter((i: any) => i !== ecosystem && i.items)
-  .concat(ecosystem.items)
+const { ecosystem: ecos } = data.site.value.themeConfig.i18n
+const ecosystem = nav.find((i: any) => i.text === ecos)
+let items = nav.filter((i: any) => i !== ecosystem && i.items)
+items = ecos?.items ?  items.concat(ecos.items) : items
 </script>
 
 <template>


### PR DESCRIPTION


## Description of Problem

The value of the ecosystem field will have different values in different language versions, currently in the `.vitepress/theme/components/SiteMap.vue` file is a fixed value, in different language versions if this fixed value is not modified will throw an error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/er-1.png?raw=true)

## Proposed Solution

Add the ecosystem field to the internationalization to get different values depending on the language version; and you need to add the.

![](https://github.com/zhoujiahua/picture/blob/master/2023/sl-1.png?raw=true)

## Additional Information

Currently, the error is thrown in Chinese and Japanese documents because the value of the `ecosystem` field is not available.

Chinese document error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/cn-1.png?raw=true)

Japanese documentation reports an error.

![](https://github.com/zhoujiahua/picture/blob/master/2023/jp-1.png?raw=true)
