### PR TITLE
Update reactivity-core.md

### DIFF
--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -480,6 +480,18 @@
     data.value = await response
   })
   ```
+当直接侦听一个响应式数组时，需要启用 `{deep: true}` 参数
+
+```js
+const ary = reactive([])
+watch(
+  ary, 
+  (value) => {
+    console.log(value)
+  },
+  { deep: true }
+)
+```
 
 - **参考：**
 


### PR DESCRIPTION
当直接侦听一个响应式数组时，需要启用 `{deep: true}` 参数

## Description of Problem
对于初学者来说监听数组真的是个深坑，我觉得应该在文档中体现。
## Proposed Solution

## Additional Information
