### PR TITLE
docs: change @vnode-mounted to @vue:mounted 

### DIFF
--- a/src/examples/src/cells/Cell/template.html
+++ b/src/examples/src/cells/Cell/template.html
@@ -4,7 +4,7 @@
     :value="cells[c][r]"
     @change="update"
     @blur="update"
-    @vnode-mounted="({ el }) => el.focus()"
+    @vue:mounted="({ el }) => el.focus()"
   >
   <span v-else>{{ evalCell(cells[c][r]) }}</span>
 </div>

--- a/src/examples/src/todomvc/App/template.html
+++ b/src/examples/src/todomvc/App/template.html
@@ -34,7 +34,7 @@
           class="edit"
           type="text"
           v-model="todo.title"
-          @vnode-mounted="({ el }) => el.focus()"
+          @vue:mounted="({ el }) => el.focus()"
           @blur="doneEdit(todo)"
           @keyup.enter="doneEdit(todo)"
           @keyup.escape="cancelEdit(todo)"

--- a/src/guide/extras/demos/SpreadSheetCell.vue
+++ b/src/guide/extras/demos/SpreadSheetCell.vue
@@ -22,7 +22,7 @@ function update(e) {
       :value="cells[c][r]"
       @change="update"
       @blur="update"
-      @vnode-mounted="({ el }) => el.focus()"
+      @vue:mounted="({ el }) => el.focus()"
     />
     <span v-else>{{ evalCell(cells[c][r]) }}</span>
   </div>


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

@vnode-* hooks in templates are deprecated. Use the vue: prefix instead. For example, @vnode-mounted should be changed to @vue:mounted. @vnode-* hooks support will be removed in 3.4.

