### PR TITLE
fix: don't redirect to html-suffix url for vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
       "source": "/assets/(.*)",
@@ -19,11 +20,16 @@
       ]
     }
   ],
+  "rewrites": [
+    {
+      "source": "/:path*",
+      "destination": "/:path*.html"
+    }
+  ],
   "redirects": [
     {
       "source": "/v2/:path*",
       "destination": "https://v2.cn.vuejs.org/v2/:path*"
     }
-  ],
-  "cleanUrls": true
+  ]
 }


### PR DESCRIPTION
### 在创建 pull request 之前

仅针对于 Vercel，Netlify 无此问题

访问 https://cn.vuejs.org/api/application.html 将会跳转到没有 `.html` 的地址，然后再跳转回来（最新 VitePress 已取消此行为 https://github.com/vuejs/vitepress/commit/ce8d139a8e70e4d0a8d06711c50119990b041078 ）

本 PR 之后：不再跳转。不论添加 html 或不添加，内容皆一致。

请确认：

- [ ] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [ ] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

