### PR TITLE
docs: add missing comments to the Options API in the transition page

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -407,6 +407,8 @@ export default {
 
     // 当进入过渡完成时调用。
     onAfterEnter(el) {},
+
+    // 当进入过渡在完成之前被取消时调用
     onEnterCancelled(el) {},
 
     // 在 leave 钩子之前调用


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述
the Options API in the transition page is missing the comment for onEnterCancelled().
add the same comment as the Composition API's onEnterCancelled().

Options API:
![image](https://github.com/vuejs-translations/docs-zh-cn/assets/47178158/7c022459-92e0-425d-ba29-666ed408a493)

Composition API:
![image](https://github.com/vuejs-translations/docs-zh-cn/assets/47178158/c2a1a1c2-b074-49cc-b622-c5ac7d811339)

