### PR TITLE
Update custom-directives.md

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -147,7 +147,7 @@ const myDirective = {
   - `dir`：指令的定义对象。
 
 - `vnode`：代表绑定元素的底层 VNode。
-- `prevNode`：代表之前的渲染中指令所绑定元素的 VNode。仅在 `beforeUpdate` 和 `updated` 钩子中可用。
+- `prevVnode`：代表之前的渲染中指令所绑定元素的 VNode。仅在 `beforeUpdate` 和 `updated` 钩子中可用。
 
 举例来说，像下面这样使用指令：
 


### PR DESCRIPTION
钩子参数解释中，prevNode修改为prevVnode。和钩子函数概率示例中各周期内参数中prevVnode不一致。

### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

