### PR TITLE
docs: fix translate mistake in /guide/essentials/class-and-style

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -222,7 +222,7 @@ Class 的绑定也是同样的：
 <p class="foo bar active">Hi!</p>
 ```
 
-如果你的组件有多个根元素，你将需要指定哪个根元素来接收这个 class。你可以通过组件的 `$attrs` 属性来实现指定：
+如果你的组件有多个根元素，你将需要指定哪个根元素来接收这个 class。你可以通过组件的 `$attrs` 属性来指定接收的元素：
 
 ```vue-html
 <!-- MyComponent 模板使用 $attrs 时 -->


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

官方文档中的 `this` 应被完整翻译为 `指定接收的元素` (**this** refer to **define which element will receive this class**)

#### 官方文档

If your component has multiple root elements, you would need to define which element will receive this class. You can do **this** using the $attrs component property:

#### 修改

```diff
- 如果你的组件有多个根元素，你将需要指定哪个根元素来接收这个 class。你可以通过组件的 `$attrs` 属性来实现指定：
+ 如果你的组件有多个根元素，你将需要指定哪个根元素来接收这个 class。你可以通过组件的 `$attrs` 属性来指定接收的元素：
```