### PR TITLE
doc: fix method handler access the DOM element way

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -108,7 +108,7 @@ methods: {
 
 </div>
 
-方法事件处理器会自动接收原生 DOM 事件并触发执行。在上面的例子中，我们能够通过被触发事件的 `event.target.tagName` 访问到该 DOM 元素。
+方法事件处理器会自动接收原生 DOM 事件并触发执行。在上面的例子中，我们能够通过被触发事件的 `event.target` 访问到该 DOM 元素。
 
 <div class="composition-api">
 


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [ √] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [√] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述
英文文档同样有问题，已合入这个PR到英文文档：https://github.com/vuejs/docs/pull/2824
问题描述：
文档中讲到事件处理器获得dom元素的方式是通过`event.target.tagName`，但我认为`event.target.tagName`获得的是dom元素的tagName，而非DOM元素本身，DOM元素本身的获取方式应该是`event.target `
