### PR TITLE
class-and-style.README-Tips: 如果把text-danger改写成textDanger,则不需要单引号括起来

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -55,6 +55,15 @@ data() {
 
 当 `isActive` 或者 `hasError` 改变时，class 列表会随之更新。举例来说，如果 `hasError` 变为 `true`，class 列表也会变成 `"static active text-danger"`。
 
+Tips: 如果把text-danger改写成textDanger,则不需要单引号括起来。代码如下：
+```vue-html
+<div
+  class="static"
+  :class="{ active: isActive, textDanger: hasError }"
+></div>
+```
+
+
 绑定的对象并不一定需要写成内联字面量的形式，也可以直接绑定一个对象：
 
 <div class="composition-api">


### PR DESCRIPTION
Tips: 如果把text-danger改写成textDanger,则不需要单引号括起来

### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

