### PR TITLE
Clarify compilerOptions.comments description in docs

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -522,7 +522,7 @@ console.log(app.config)
 
 ### app.config.compilerOptions.comments {#app-config-compileroptions-comments}
 
-用于调整是否移除模板中的 HTML 注释。
+用于调整是否保留模板中的 HTML 注释。
 
 - **类型** `boolean`
 

--- a/src/api/application.md
+++ b/src/api/application.md
@@ -522,7 +522,7 @@ console.log(app.config)
 
 ### app.config.compilerOptions.comments {#app-config-compileroptions-comments}
 
-用于调整是否保留模板中的 HTML 注释。
+用于调整模板中 HTML 注释的处理方式。
 
 - **类型** `boolean`
 


### PR DESCRIPTION
The current documentation states that compilerOptions.comments controls  "whether to remove HTML comments", which may cause confusion. 

In practice:
- Default (false): comments are removed in production builds.
- True: comments are retained even in production.

This commit updates the description to clarify that the option  actually controls whether comments are preserved, not removed.

### 在创建 pull request 之前

请确认：

- [ ] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [ ] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

