### PR TITLE
docs(reactivity-watchers.md): remove ambiguous “versions before 3.5” statement from watcher onCleanup section

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -486,7 +486,7 @@ export default {
 
 </div>
 
-这在 3.5 之前的版本有效。此外，通过函数参数传递的 `onCleanup` 与侦听器实例相绑定，因此不受 `onWatcherCleanup` 的同步限制。
+此外，通过函数参数传递的 `onCleanup` 与侦听器实例相绑定，因此不受 `onWatcherCleanup` 的同步限制。
 
 ## 回调的触发时机 {#callback-flush-timing}
 


### PR DESCRIPTION
### 在创建 pull request 之前

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

Removed the ambiguous line “这在 3.5 之前的版本有效”.

The onCleanup callback argument remains available in 3.5+, so the old note could mislead readers into thinking it was deprecated; dropping it keeps the wording accurate and concise.

