### PR TITLE
fix: update Vite links from vitejs.dev to vite.dev

### DIFF
--- a/src/api/compile-time-flags.md
+++ b/src/api/compile-time-flags.md
@@ -38,7 +38,7 @@ outline: deep
 
 ### Vite {#vite}
 
-`@vitejs/plugin-vue` 会自动为这些标志提供默认值。要更改默认值，请使用 Vite 的 [`define` 配置项](https://vitejs.dev/config/shared-options.html#define)：
+`@vitejs/plugin-vue` 会自动为这些标志提供默认值。要更改默认值，请使用 Vite 的 [`define` 配置项](https://vite.dev/config/shared-options.html#define)：
 
 ```js [vite.config.js]
 import { defineConfig } from 'vite'

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -26,7 +26,7 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 - 已安装 `^20.19.0 || >=22.12.0` 版本的 [Node.js](https://nodejs.org/)
 :::
 
-在本节中，我们将介绍如何在本地搭建 Vue [单页应用](/guide/extras/ways-of-using-vue#single-page-application-spa)。创建的项目将使用基于 [Vite](https://vitejs.dev) 的构建设置，并允许我们使用 Vue 的[单文件组件](/guide/scaling-up/sfc) (SFC)。
+在本节中，我们将介绍如何在本地搭建 Vue [单页应用](/guide/extras/ways-of-using-vue#single-page-application-spa)。创建的项目将使用基于 [Vite](https://vite.dev) 的构建设置，并允许我们使用 Vue 的[单文件组件](/guide/scaling-up/sfc) (SFC)。
 
 确保你安装了最新版本的 [Node.js](https://nodejs.org/)，并且你的当前工作目录正是打算创建项目的目录。在命令行中运行以下命令 (不要带上 `$` 符号)：
 

--- a/src/guide/reusability/plugins.md
+++ b/src/guide/reusability/plugins.md
@@ -135,4 +135,4 @@ export default {
 
 ### 为 NPM 打包
 
-如果你想进一步打包并发布插件给他人使用，请参阅 [Vite 库模式](https://vitejs.dev/guide/build.html#library-mode)。
+如果你想进一步打包并发布插件给他人使用，请参阅 [Vite 库模式](https://vite.dev/guide/build.html#library-mode)。

--- a/src/tutorial/src/step-1/description.md
+++ b/src/tutorial/src/step-1/description.md
@@ -30,7 +30,7 @@
 import { ... } from 'vue/dist/vue.esm-bundler.js'
 ```
 
-要么通过配置构建工具来正确解析 `vue`。以下是 [Vite](https://vitejs.dev/) 配置的示例：
+要么通过配置构建工具来正确解析 `vue`。以下是 [Vite](https://vite.dev/) 配置的示例：
 
 ```js [vite.config.js]
 export default {


### PR DESCRIPTION
 ### 在创建 pull request 之前

  请确认：

  - [x] 我已经阅读过项目的 wiki 了解相关注意事项。
  - [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至英文文档仓库讨论，相关结论会被定期从英文版同步)

  ### 问题描述

  同步上游英文文档的变更 (#3337)，将 Vite 文档链接从旧域名 `vitejs.dev` 更新为 `vite.dev`。

  修改的文件：
  - `src/api/compile-time-flags.md`
  - `src/guide/quick-start.md`
  - `src/guide/reusability/plugins.md`
  - `src/tutorial/src/step-1/description.md`

  仅更新了英文 Vite 链接，中文 Vite 文档链接 (`cn.vitejs.dev`) 保持不变。
