### PR TITLE
docs: sync missing content and global directive typing

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -229,6 +229,31 @@ watch(
 
 ![Chrome 开发者工具通过 aria-labelledby 展示 input 的无障碍访问名称](./images/AccessibleARIAlabelledbyDevTools.png)
 
+在可复用组件中使用这种模式时，请通过 [`useId()`](/api/composition-api-helpers.html#useid) 生成 ID，而不要将其硬编码。这样既能让每个组件实例的 `id` 值保持唯一，又能将可见文本与表单控件关联起来：
+
+```vue
+<script setup>
+import { useId } from 'vue'
+
+const sectionId = useId()
+const nameId = useId()
+</script>
+
+<template>
+  <section class="form-section">
+    <h2 :id="sectionId">Billing</h2>
+
+    <label :id="nameId" :for="`${nameId}-input`">Name: </label>
+    <input
+      :id="`${nameId}-input`"
+      type="text"
+      name="name"
+      :aria-labelledby="`${sectionId} ${nameId}`"
+    />
+  </section>
+</template>
+```
+
 #### `aria-describedby` {#aria-describedby}
 
 [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) 的用法与 `aria-labelledby` 相同，它提供了一条用户可能需要的附加描述信息。这可用于描述任何输入的标准：

--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -338,6 +338,30 @@ const post = {
 <BlogPost :id="post.id" :title="post.title" />
 ```
 
+### 合并多个绑定时的行为 {#merge-behavior-when-combining-bindings}
+
+当 `v-bind` 和显式绑定同时用在同一个组件上时，Vue 内部会调用 `mergeProps()` 将它们合并。合并策略取决于键的类型：
+
+- **普通 props**——后面的值会覆盖前面的值：
+
+```vue-html
+<!-- title === 'bar' -->
+<BlogPost title="foo" v-bind="{ title: 'bar' }" />
+```
+
+- **事件监听器**——通过 `v-bind` 对象传递监听器时，请[使用 `onEventName` 键名约定](/guide/extras/render-function#v-on)。同一事件的所有处理函数都会被调用 (参见 [`v-on` 监听器继承](/guide/components/attrs#v-on-listener-inheritance))：
+
+```vue-html
+<!-- 打印 1 和 2 -->
+<BlogPost @click="console.log(1)" v-bind="{ onClick: () => console.log(2) }" />
+```
+
+- **`class` 和 `style`** 遵循类似的合并策略 (参见 [`class` 和 `style` 合并](/guide/components/attrs#class-and-style-merging))。
+
+:::tip
+完整的合并规则请参阅 [`mergeProps()`](/api/render-function#mergeprops) API 参考。
+:::
+
 ## 单向数据流 {#one-way-data-flow}
 
 所有的 props 都遵循着**单向绑定**原则，props 因父组件的更新而变化，自然地将新的状态向下流往子组件，而不会逆向传递。这避免了子组件意外修改父组件的状态的情况，不然应用的数据流将很容易变得混乱而难以理解。

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -481,7 +481,7 @@ const openModal = () => {
 
 ## 为自定义全局指令添加类型 {#typing-global-custom-directives}
 
-可以通过扩展 `ComponentCustomProperties` 来为使用 `app.directive()` 声明的全局自定义指令获取类型提示和类型检查
+可以通过扩展 `GlobalDirectives` 来为使用 `app.directive()` 声明的全局自定义指令获取类型提示和类型检查
 
 ```ts [src/directives/highlight.ts]
 import type { Directive } from 'vue'
@@ -489,7 +489,7 @@ import type { Directive } from 'vue'
 export type HighlightDirective = Directive<HTMLElement, string>
 
 declare module 'vue' {
-  export interface ComponentCustomProperties {
+  export interface GlobalDirectives {
     // 使用 v 作为前缀 (v-highlight)
     vHighlight: HighlightDirective
   }


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述

同步当前英文文档中尚未体现在中文文档里的内容：

  - 补充 Props 中多个绑定的合并行为，包括普通 props、事件监听器、`class` 和 `style` 的合并规则。
  - 补充无障碍访问文档中使用 `useId()` 为可复用组件生成唯一 ID 的说明和示例。
  - 将全局自定义指令的类型扩展方式从 `ComponentCustomProperties` 更新为 `GlobalDirectives`。

  对应英文文档：

  - https://vuejs.org/guide/components/props.html#merge-behavior-when-combining-bindings
  - https://vuejs.org/guide/best-practices/accessibility.html#aria-labelledby
  - https://vuejs.org/guide/typescript/composition-api.html#typing-global-custom-directives
