### PR TITLE
feat(autopr): enhance translation workflow with ignore/skip/modified-files support

### DIFF
--- a/.github/scripts/auto-pr/bin/stage.js
+++ b/.github/scripts/auto-pr/bin/stage.js
@@ -7,14 +7,11 @@ import { translateConflicts } from "../src/translator.js";
 import { applyTranslations } from "../src/apply-translations.js";
 import { collectMergeInfo } from "../src/collect-merge-info.js";
 import { createPrAndRequestReview } from "../src/create-pr-and-review.js";
-import { AUTO_PR_DIR, ROOT, readState, writeState } from "../src/helpers.js";
+import { AUTO_PR_DIR, ROOT, isLocal, readJson, readState, writeState } from "../src/helpers.js";
 
 const TODO_PATH = resolve(AUTO_PR_DIR, "todo-translation.json");
 const DONE_PATH = resolve(AUTO_PR_DIR, "done-translation.json");
-
-function isLocal() {
-  return process.env.LOCAL === "true";
-}
+const IGNORE_GLOBS = "src/style-guide/*"; // 忽略翻译的文件 glob 列表，逗号分隔，src/style-guide/*
 
 function isTruthy(value) {
   return value === true || value === "true" || value === "1";
@@ -94,7 +91,12 @@ async function prepareStage() {
   console.log("Stage 1/3: prepare before AI translation");
   removeGeneratedArtifacts();
   configureGitUser();
-  command(`git fetch origin ${upstreamBranch}`, { inherit: true });
+  if (!isLocal()) {
+    command(`git fetch origin ${upstreamBranch}`, { inherit: true });
+    command(`git fetch origin ${syncBranch}`, { inherit: true });
+    // 切换到 sync 分支，确保 merge、commit、push 都以 sync 为目标
+    command(`git checkout -B ${syncBranch} origin/${syncBranch}`, { inherit: true });
+  }
 
   const syncBaseHash = getSyncBaseHash(upstreamBranch);
   const detected = await detectChanges({ upstreamBranch, syncBranch });
@@ -107,6 +109,8 @@ async function prepareStage() {
     upstream_hash: detected.upstream_hash,
     detect_changed_files: detected.changed_files,
     upstream_behind_count: detected.upstream_behind_count,
+    // 特定文件跳过翻译，命中这个 glob 匹配的文件，不会在 todo-translation.json 中生成
+    ignore_globs: IGNORE_GLOBS,
   };
 
   if (detected.merge_result === "no_changes") {
@@ -120,20 +124,22 @@ async function prepareStage() {
     return;
   }
 
-  const existingSyncPrCount = checkExistingSyncPr();
-  if (existingSyncPrCount > 0) {
-    writeState({
-      ...baseState,
-      existing_sync_pr_count: existingSyncPrCount,
-      has_changes: false,
-      merge_result: "blocked_by_existing_pr",
-      merge_status: "blocked",
-    });
-    console.log(
-      `Found ${existingSyncPrCount} open PR(s) with label '从英文版同步'. ` +
-      "A previous sync is still in review. Skipping translation pipeline.",
-    );
-    return;
+  if (!isLocal()) {
+    const existingSyncPrCount = checkExistingSyncPr();
+    if (existingSyncPrCount > 0) {
+      writeState({
+        ...baseState,
+        existing_sync_pr_count: existingSyncPrCount,
+        has_changes: false,
+        merge_result: "blocked_by_existing_pr",
+        merge_status: "blocked",
+      });
+      console.log(
+        `Found ${existingSyncPrCount} open PR(s) with label '从英文版同步'. ` +
+          "A previous sync is still in review. Skipping translation pipeline.",
+      );
+      return;
+    }
   }
 
   if (isLocal()) {
@@ -152,10 +158,12 @@ async function prepareStage() {
     console.log("Merge has conflicts. Resolving conflict blocks before translation.");
   }
 
-  if (mergeStatus === "conflict") {
-    const replacements = resolveConflicts();
-    console.log(`Prepared ${replacements.length} conflict block(s) for translation.`);
+  // 无论是否有冲突，都要检测新文件/修改文件加入翻译队列
+  const replacements = resolveConflicts();
+  if (replacements.length > 0) {
+    console.log(`Prepared ${replacements.length} item(s) for translation.`);
   }
+  console.log("[todo-translation.json]", JSON.stringify(readJson(TODO_PATH, []), null, 2));
 
   writeState({
     ...baseState,
@@ -184,8 +192,10 @@ async function translateStage() {
     return;
   }
 
-  if (state.merge_status !== "conflict") {
-    console.log("Merge was clean. No conflict translation is required.");
+  // 检查是否存在待翻译内容（来自冲突、新增文件、或修改文件）
+  const hasTodoItems = existsSync(TODO_PATH);
+  if (!hasTodoItems) {
+    console.log("No todo-translation.json found. No translation needed.");
     writeState({ ...state, translation_status: "skipped" });
     return;
   }
@@ -209,8 +219,11 @@ async function translateStage() {
   }
 
   let applied = false;
+  console.log("[done-translation.json]", JSON.stringify(readJson(DONE_PATH, []), null, 2));
   if (existsSync(DONE_PATH)) {
     applyTranslations();
+    // 将翻译后的内容重新暂存，确保 staging area 包含中文版
+    command("git add -A", { inherit: true });
     applied = true;
   } else {
     console.log("No done-translation.json found. Nothing to apply.");
@@ -257,6 +270,7 @@ async function submitStage() {
     merge_result: info.merge_result,
     conflict_files: info.conflict_files,
     changed_files: info.changed_files,
+    create_pr: isTruthy(process.env.CREATE_PR),
   };
   writeState(nextState);
 
@@ -297,6 +311,7 @@ sync #${nextState.upstream_hash}`;
     mergeResult: nextState.merge_result,
     conflictFiles: nextState.conflict_files,
     changedFiles: nextState.changed_files,
+    skipCreatePr: !nextState.create_pr,
     githubRepository: process.env.GITHUB_REPOSITORY,
     ghToken: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   });

--- a/.github/scripts/auto-pr/src/create-pr-and-review.js
+++ b/.github/scripts/auto-pr/src/create-pr-and-review.js
@@ -66,7 +66,8 @@ export function buildPrBody({
 }
 
 export async function createPrAndRequestReview(options = {}) {
-  const repo = options.githubRepository || process.env.GITHUB_REPOSITORY || "vuejs-translations/docs-zh-cn";
+  const repo =
+    options.githubRepository || process.env.GITHUB_REPOSITORY || "vuejs-translations/docs-zh-cn";
   const upstreamRepo = options.upstreamRepo || process.env.UPSTREAM_REPO;
   const syncBranch = options.syncBranch || process.env.SYNC_BRANCH;
   const targetBranch = options.targetBranch || process.env.TARGET_BRANCH;
@@ -75,6 +76,7 @@ export async function createPrAndRequestReview(options = {}) {
   const mergeResult = options.mergeResult || process.env.MERGE_RESULT;
   const local = options.local ?? process.env.LOCAL === "true";
   const ghToken = options.ghToken || process.env.GH_TOKEN;
+  const skipCreatePr = options.skipCreatePr ?? process.env.CREATE_PR !== "true";
 
   const { conflictFiles, changedFiles } = readArtifactFiles({
     conflictFiles: options.conflictFiles || process.env.CONFLICT_FILES,
@@ -97,6 +99,12 @@ export async function createPrAndRequestReview(options = {}) {
     return { prNumber: null, title, body };
   }
 
+  if (skipCreatePr) {
+    console.log(`[skip-create-pr] PR creation skipped. Title: ${title}`);
+    console.log(`[skip-create-pr] PR Body:\n${body}`);
+    return { prNumber: null, title, body };
+  }
+
   const existing = gh(
     `gh pr list --repo "${repo}" --base "${targetBranch}" --head "${syncBranch}" --state open --json number --jq '.[0].number'`,
   );
@@ -110,7 +118,7 @@ export async function createPrAndRequestReview(options = {}) {
     const tmpFile = "/tmp/pr-body.md";
     writeFileSync(tmpFile, body, "utf-8");
     const prUrl = gh(
-      `gh pr create --repo "${repo}" --base "${targetBranch}" --head "${syncBranch}" --title "${title}" --body-file "${tmpFile}" --label "从英文版同步" --label "请使用 merge commit 合并"`,
+      `gh pr create --repo "${repo}" --base "${targetBranch}" --head "${syncBranch}" --title "${title}" --body-file "${tmpFile}" --label "从英文版同步" --label "请使用 merge commit 合并" --label "autopr(自动合并工作流)"`,
     );
     unlinkSync(tmpFile);
 

--- a/.github/scripts/auto-pr/src/detect-changes.js
+++ b/.github/scripts/auto-pr/src/detect-changes.js
@@ -1,5 +1,5 @@
 import SimpleGit from "simple-git";
-import { isDirectRun, ROOT, setOutput } from "./helpers.js";
+import { isDirectRun, isLocal, ROOT, setOutput } from "./helpers.js";
 
 const git = SimpleGit(ROOT);
 
@@ -7,10 +7,15 @@ export async function detectChanges({
   upstreamBranch = process.env.UPSTREAM_BRANCH || "upstream",
   syncBranch = process.env.SYNC_BRANCH || "sync",
 } = {}) {
-  await git.fetch("origin");
+  if (!isLocal()) {
+    await git.fetch("origin");
+  }
+
+  const upstreamRef = isLocal() ? upstreamBranch : `origin/${upstreamBranch}`;
+  const syncRef = isLocal() ? syncBranch : `origin/${syncBranch}`;
 
   // Get upstream hash
-  const upstreamHash = (await git.raw(["rev-parse", "--short", "origin/" + upstreamBranch])).trim();
+  const upstreamHash = (await git.raw(["rev-parse", "--short", upstreamRef])).trim();
   console.log(`Upstream hash: ${upstreamHash}`);
 
   // Check if there are upstream commits not yet in sync
@@ -18,7 +23,7 @@ export async function detectChanges({
     await git.raw([
       "rev-list",
       "--count",
-      `origin/${syncBranch}..origin/${upstreamBranch}`,
+      `${syncRef}..${upstreamRef}`,
     ])
   ).trim();
 
@@ -38,8 +43,8 @@ export async function detectChanges({
   const diff = await git.diff([
     "--name-only",
     "--diff-filter=ACMR",
-    `origin/${syncBranch}`,
-    `origin/${upstreamBranch}`,
+    `${syncRef}`,
+    upstreamRef,
     "--",
     "src/**/*.md",
   ]);

--- a/.github/scripts/auto-pr/src/helpers.js
+++ b/.github/scripts/auto-pr/src/helpers.js
@@ -8,6 +8,10 @@ export const AUTO_PR_DIR = resolve(SRC_DIR, "..");
 export const ROOT = resolve(AUTO_PR_DIR, "..", "..", "..");
 export const STATE_PATH = resolve(AUTO_PR_DIR, "autopr-state.json");
 
+export function isLocal() {
+  return process.env.LOCAL === "true";
+}
+
 export function isDirectRun(metaUrl) {
   return process.argv[1] && fileURLToPath(metaUrl) === resolve(process.argv[1]);
 }
@@ -40,4 +44,31 @@ export function writeState(state) {
     ...state,
     updated_at: new Date().toLocaleString(),
   });
+}
+
+// ── Glob 匹配工具 ──
+
+/**
+ * 轻量 glob 匹配，支持 * 和 **
+ */
+export function isGlobMatch(file, pattern) {
+  const regex = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "<<GLOBSTAR>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<GLOBSTAR>>/g, ".*");
+  return new RegExp(`^${regex}$`).test(file);
+}
+
+/**
+ * 判断文件是否匹配 ignore_globs（逗号分隔的 glob 列表）
+ * ignoreGlobs: "src/style-guide/*,src/foo/*" 或空字符串
+ */
+export function isFileIgnored(file, ignoreGlobs) {
+  if (!ignoreGlobs) return false;
+  return ignoreGlobs
+    .split(",")
+    .map((g) => g.trim())
+    .filter(Boolean)
+    .some((pattern) => isGlobMatch(file, pattern));
 }

--- a/.github/scripts/auto-pr/src/resolve-conflicts.js
+++ b/.github/scripts/auto-pr/src/resolve-conflicts.js
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
-import { AUTO_PR_DIR, isDirectRun, readState } from "./helpers.js";
+import { AUTO_PR_DIR, isDirectRun, isFileIgnored, isGlobMatch, readState } from "./helpers.js";
 
 const TODO_PATH = resolve(AUTO_PR_DIR, "todo-translation.json");
 
@@ -17,16 +17,6 @@ const DEFAULT_ACCEPT_INCOMING_LIST = {
   "**/*.ts": "markers",
   "**/*.json": "markers",
 };
-
-// 轻量 glob 匹配，支持 * 和 **
-function isGlobMatch(file, pattern) {
-  const regex = pattern
-    .replace(/[.+^${}()|[\]\\]/g, "\\$&") // 转义特殊字符
-    .replace(/\*\*/g, "<<GLOBSTAR>>")
-    .replace(/\*/g, "[^/]*")
-    .replace(/<<GLOBSTAR>>/g, ".*");
-  return new RegExp(`^${regex}$`).test(file);
-}
 
 // 将 markdown 内容按段落拆分，保护代码块内部的空行
 function splitIntoParagraphs(content) {
@@ -229,6 +219,7 @@ class GitConflictFinder {
           }
 
           writeFileSync(file, lines.join("\n"), "utf-8");
+          this.stageFile(file);
         }
       });
     }
@@ -268,6 +259,88 @@ class GitConflictFinder {
     }
   }
 
+  // ── 阶段3：检测内容有变更的已有文件 ──
+  handleModifiedFiles() {
+    const { sync_branch, upstream_branch } = readState();
+    if (!sync_branch || !upstream_branch) {
+      console.error(this.colorize("red", "\n 无有效的同步分支或上游分支"));
+      return;
+    }
+
+    const output = this.exec(
+      `git diff --diff-filter=M --name-only ${sync_branch} ${upstream_branch} -- :(glob)src/**/*.md`,
+    );
+    const modifiedFiles = output.split("\n").filter(Boolean);
+    if (modifiedFiles.length === 0) {
+      console.log(this.colorize("cyan", "\n📝 没有修改的 .md 文件"));
+      return;
+    }
+
+    // 获取 merge-base，即上游上次同步的位置
+    const mergeBase = this.exec(`git merge-base ${sync_branch} ${upstream_branch}`);
+    if (!mergeBase) {
+      console.error(this.colorize("red", "\n 无法获取 merge-base"));
+      return;
+    }
+
+    console.log(this.colorize("yellow", `\n📝 发现 ${modifiedFiles.length} 个修改文件 (merge-base: ${mergeBase}):\n`));
+
+    for (const file of modifiedFiles) {
+      // 对比上游英文版自身的变化（merge-base vs 当前 upstream）
+      const diffOutput = this.exec(
+        `git diff --unified=0 ${mergeBase} ${upstream_branch} -- "${file}"`,
+      );
+      if (!diffOutput) {
+        console.log(`   ⏭️  ${file} (无差异)`);
+        continue;
+      }
+
+      // 解析 hunk 头，提取上游新版本中受影响行的行号
+      const changedLines = new Set();
+      for (const line of diffOutput.split("\n")) {
+        const match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+        if (match) {
+          const start = parseInt(match[1], 10);
+          const count = parseInt(match[2] || "1", 10);
+          for (let i = start; i < start + count; i++) {
+            changedLines.add(i);
+          }
+        }
+      }
+
+      if (changedLines.size === 0) {
+        console.log(`   ✓ ${file} (无新增行)`);
+        continue;
+      }
+
+      // 读取合并后的文件，找到包含变更行的段落
+      const mergedContent = readFileSync(file, "utf-8");
+      const paragraphs = splitIntoParagraphs(mergedContent);
+
+      const changedParas = paragraphs.filter((para) => {
+        const [pStart, pEnd] = para.lines;
+        for (let line = pStart; line <= pEnd; line++) {
+          if (changedLines.has(line)) return true;
+        }
+        return false;
+      });
+
+      if (changedParas.length > 0) {
+        for (const para of changedParas) {
+          this.replacements.push({
+            current: "",
+            incoming: para.incoming,
+            file,
+            lines: para.lines,
+          });
+        }
+        console.log(`   ✏️ ${file} (${changedParas.length} 个受影响段落) → 加入翻译队列`);
+      } else {
+        console.log(`   ✓ ${file} (段落无变化)`);
+      }
+    }
+  }
+
   run() {
     console.log(this.colorize("blue", "========================================"));
     console.log(this.colorize("blue", "Vuejs 中文仓库处理 Git 冲突扫描器 (ES6 版本)"));
@@ -277,6 +350,8 @@ class GitConflictFinder {
     this.handleConflictFiles();
     // ── 阶段2：处理新文件 ──
     this.handleNewFiles();
+    // ── 阶段3：处理有变更的已有文件 ──
+    this.handleModifiedFiles();
   }
 }
 
@@ -285,13 +360,36 @@ export function resolveConflicts() {
   const finder = new GitConflictFinder(replacements);
   finder.run();
 
+  // 过滤掉被 ignore_globs 排除的文件
+  const { ignore_globs } = readState();
+  let filtered = replacements;
+  if (ignore_globs) {
+    filtered = replacements.filter((item) => !isFileIgnored(item.file, ignore_globs));
+
+    const excludedFiles = [
+      ...new Set(
+        replacements
+          .filter((item) => isFileIgnored(item.file, ignore_globs))
+          .map((item) => item.file),
+      ),
+    ];
+    if (excludedFiles.length > 0) {
+      console.log(
+        `\n以下文件匹配 ignore_globs ("${ignore_globs}")，跳过 AI 翻译:`,
+      );
+      excludedFiles.forEach((f) => console.log(`  ⏭️  ${f}`));
+      const excludedCount = replacements.length - filtered.length;
+      console.log(`共排除 ${excludedFiles.length} 个文件（${excludedCount} 个条目）\n`);
+    }
+  }
+
   writeFileSync(
     TODO_PATH,
-    JSON.stringify(replacements, ["file", "lines", "current", "incoming"], 2),
+    JSON.stringify(filtered, ["file", "lines", "current", "incoming"], 2),
     "utf-8",
   );
 
-  return replacements;
+  return filtered;
 }
 
 if (isDirectRun(import.meta.url)) {

--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       skip_translate_gate:
-        description: "Skip translation failure gate (allow PR even if AI translation fails)"
+        description: "翻译失败时仍继续"
         type: boolean
         default: false
+      create_pr:
+        description: "创建 PR（取消不创建，方便调试）"
+        type: boolean
+        default: true
       translate_provider:
         description: "AI CLI used by the translation stage"
         type: choice
@@ -33,6 +37,7 @@ env:
   TARGET_BRANCH: main
   TRANSLATE_PROVIDER: ${{ github.event.inputs.translate_provider || 'copilot' }}
   SKIP_TRANSLATE_GATE: ${{ github.event.inputs.skip_translate_gate || 'false' }}
+  CREATE_PR: ${{ github.event.inputs.create_pr || 'true' }}
 
 jobs:
   sync-translate-submit:
@@ -40,11 +45,11 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      COPILOT_TOKEN: ${{ secrets.COPILOT_TOKEN }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.SYNC_BRANCH }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 问题描述


  1. 新增 ignore_globs 跳过机制
      - `src/style-guide/*` 默认跳过 AI 翻译，不会出现在 `todo-translation.json` 中
      - 在 `.github\scripts\auto-pr\bin\stage.js` 中维护
      - 通过 glob 匹配过滤文件，排除的文件会打印日志

  2. 新增 `skip_create_pr` 选项
      - 工作流支持 `create_pr` 参数，设为 `false` 时不创建 PR，仅输出标题和内容，方便调试

  3. 支持非冲突文件的翻译
      - 之前只处理有 git 冲突的文件
      - 现在新增 `handleModifiedFiles()`：对比 merge-base 找出上游有内容变更的已有文件，将受影响的段落也加入翻译队列

  4. 本地开发模式支持
      - 抽取 `isLocal()` 到 helpers，本地运行时跳过  `git fetch、checkout、PR` 检查等远程操作
      - `detect-changes.js` 中的 git ref 适配本地/远程分支

 5. 工作流配置调整
  - checkout 使用 github.ref_name 替代硬编码分支名，由 `Github Actions` 界面传入，作为解耦，但实际依然是 `upstream 合并到 sync` 分支，
    - PR 自动添加 autopr 标签：`autopr(自动合并工作流)`
  
6. `COPILOT_TOKEN` -> `COPILOT_GITHUB_TOKEN`
    - 这会影响 Copilot 的授权
