### PR TITLE
feat(autopr): refactor auto-pr pipeline with IGNORE_GLOBS and conflict resolution

### DIFF
--- a/.github/scripts/auto-pr/bin/stage.js
+++ b/.github/scripts/auto-pr/bin/stage.js
@@ -7,7 +7,16 @@ import { translateConflicts } from "../src/translator.js";
 import { applyTranslations } from "../src/apply-translations.js";
 import { collectMergeInfo } from "../src/collect-merge-info.js";
 import { createPrAndRequestReview } from "../src/create-pr-and-review.js";
-import { AUTO_PR_DIR, ROOT, isLocal, readJson, readState, writeState } from "../src/helpers.js";
+import {
+  AUTO_PR_DIR,
+  ROOT,
+  STATE_PATH,
+  isFileIgnored,
+  isLocal,
+  readJson,
+  readState,
+  writeState,
+} from "../src/helpers.js";
 
 const TODO_PATH = resolve(AUTO_PR_DIR, "todo-translation.json");
 const DONE_PATH = resolve(AUTO_PR_DIR, "done-translation.json");
@@ -38,7 +47,7 @@ function git(args) {
 }
 
 function removeGeneratedArtifacts() {
-  for (const path of [TODO_PATH, DONE_PATH]) {
+  for (const path of [TODO_PATH, DONE_PATH, STATE_PATH]) {
     if (existsSync(path)) unlinkSync(path);
   }
 }
@@ -96,6 +105,8 @@ async function prepareStage() {
     command(`git fetch origin ${syncBranch}`, { inherit: true });
     // 切换到 sync 分支，确保 merge、commit、push 都以 sync 为目标
     command(`git checkout -B ${syncBranch} origin/${syncBranch}`, { inherit: true });
+    // 创建本地 upstream 分支指向 origin/upstream，供后续 git diff/merge-base 使用
+    command(`git branch -f ${upstreamBranch} origin/${upstreamBranch}`, { inherit: true });
   }
 
   const syncBaseHash = getSyncBaseHash(upstreamBranch);
@@ -113,6 +124,17 @@ async function prepareStage() {
     ignore_globs: IGNORE_GLOBS,
   };
 
+  // 打印被 IGNORE_GLOBS 忽略的文件清单
+  if (IGNORE_GLOBS && detected.changed_files) {
+    const changedFiles = detected.changed_files.split(",").filter(Boolean);
+    const ignoredFiles = changedFiles.filter((file) => isFileIgnored(file, IGNORE_GLOBS));
+    if (ignoredFiles.length > 0) {
+      console.log(`\n以下文件匹配 ignore_globs ("${IGNORE_GLOBS}")，跳过 AI 翻译:`);
+      ignoredFiles.forEach((f) => console.log(`  ⏭️  ${f}`));
+      console.log(`共 ${ignoredFiles.length} 个文件将被排除在翻译队列之外\n`);
+    }
+  }
+
   if (detected.merge_result === "no_changes") {
     writeState({
       ...baseState,
@@ -124,21 +146,14 @@ async function prepareStage() {
     return;
   }
 
+  let existingSyncPrCount = 0;
   if (!isLocal()) {
-    const existingSyncPrCount = checkExistingSyncPr();
+    existingSyncPrCount = checkExistingSyncPr();
     if (existingSyncPrCount > 0) {
-      writeState({
-        ...baseState,
-        existing_sync_pr_count: existingSyncPrCount,
-        has_changes: false,
-        merge_result: "blocked_by_existing_pr",
-        merge_status: "blocked",
-      });
       console.log(
         `Found ${existingSyncPrCount} open PR(s) with label '从英文版同步'. ` +
-          "A previous sync is still in review. Skipping translation pipeline.",
+          "Will generate todo-translation.json but skip AI translation.",
       );
-      return;
     }
   }
 
@@ -159,18 +174,20 @@ async function prepareStage() {
   }
 
   // 无论是否有冲突，都要检测新文件/修改文件加入翻译队列
+  // 先写入 state（含 ignore_globs），供 resolveConflicts 读取过滤
+  writeState({
+    ...baseState,
+    existing_sync_pr_count: existingSyncPrCount,
+    merge_result: mergeStatus,
+    merge_status: mergeStatus,
+    has_changes: true,
+  });
+
   const replacements = resolveConflicts();
   if (replacements.length > 0) {
     console.log(`Prepared ${replacements.length} item(s) for translation.`);
   }
   console.log("[todo-translation.json]", JSON.stringify(readJson(TODO_PATH, []), null, 2));
-
-  writeState({
-    ...baseState,
-    merge_result: mergeStatus,
-    merge_status: mergeStatus,
-    has_changes: true,
-  });
 }
 
 async function translateStage() {
@@ -276,6 +293,8 @@ async function submitStage() {
 
   if (isLocal()) {
     console.log("[local dry-run] Skipping commit and push to sync.");
+  } else if (!nextState.create_pr) {
+    console.log("[skip-create-pr] CREATED_PR=false, skipping commit and push.");
   } else {
     command("git add -A", { inherit: true });
 
@@ -312,6 +331,8 @@ sync #${nextState.upstream_hash}`;
     conflictFiles: nextState.conflict_files,
     changedFiles: nextState.changed_files,
     skipCreatePr: !nextState.create_pr,
+    ignoreGlobs: nextState.ignore_globs,
+    detectChangedFiles: nextState.detect_changed_files,
     githubRepository: process.env.GITHUB_REPOSITORY,
     ghToken: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   });

--- a/.github/scripts/auto-pr/src/apply-translations.js
+++ b/.github/scripts/auto-pr/src/apply-translations.js
@@ -29,7 +29,7 @@ export function applyTranslations() {
     const getRange = (c) => c.lines ?? [c.line, c.line];
 
     const filePath = resolve(ROOT, file);
-    const lines = readFileSync(filePath, "utf-8").split("\n");
+    const lines = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").split("\n");
 
     // 记录每次替换后行数的变化，修正后续冲突的行号
     let offset = 0;

--- a/.github/scripts/auto-pr/src/create-pr-and-review.js
+++ b/.github/scripts/auto-pr/src/create-pr-and-review.js
@@ -34,6 +34,8 @@ export function buildPrBody({
   mergeResult,
   conflictFiles,
   changedFiles,
+  ignoreGlobs = "",
+  detectChangedFiles = "",
 }) {
   let body = `## Upstream Sync\n\n- Upstream: \`${upstreamRepo}\` @ \`${upstreamHash}\`\n- Merge result: \`${mergeResult}\`\n`;
 
@@ -59,6 +61,29 @@ export function buildPrBody({
       .map((f) => `- ${f.trim()}`)
       .join("\n");
     body += "\n";
+  }
+
+  if (ignoreGlobs && detectChangedFiles) {
+    const files = detectChangedFiles.split(",").filter(Boolean);
+    const ignored = files.filter((f) => {
+      return ignoreGlobs
+        .split(",")
+        .map((g) => g.trim())
+        .filter(Boolean)
+        .some((pattern) => {
+          const regex = pattern
+            .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+            .replace(/\*\*/g, "<<GS>>")
+            .replace(/\*/g, "[^/]*")
+            .replace(/<<GS>>/g, ".*");
+          return new RegExp(`^${regex}$`).test(f);
+        });
+    });
+    if (ignored.length > 0) {
+      body += `### Skipping files (IGNORE_GLOBS)\n`;
+      body += ignored.map((f) => `- \`${f}\``).join("\n");
+      body += "\n";
+    }
   }
 
   body += `\n> Automated by [autopr.yml](.github/workflows/autopr.yml)\n`;
@@ -91,6 +116,8 @@ export async function createPrAndRequestReview(options = {}) {
     mergeResult,
     conflictFiles,
     changedFiles,
+    ignoreGlobs: options.ignoreGlobs,
+    detectChangedFiles: options.detectChangedFiles,
   });
 
   if (local) {

--- a/.github/scripts/auto-pr/src/resolve-conflicts.js
+++ b/.github/scripts/auto-pr/src/resolve-conflicts.js
@@ -18,347 +18,271 @@ const DEFAULT_ACCEPT_INCOMING_LIST = {
   "**/*.json": "markers",
 };
 
-// 将 markdown 内容按段落拆分，保护代码块内部的空行
-function splitIntoParagraphs(content) {
-  const lines = content.split("\n");
-  const paragraphs = [];
-  let start = 0;
-  let inCodeBlock = false;
+// ============================================================
+// 工具函数
+// ============================================================
 
-  for (let i = 0; i < lines.length; i++) {
-    // 检测代码块边界
-    if (/^```/.test(lines[i])) {
-      inCodeBlock = !inCodeBlock;
-    }
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+  magenta: "\x1b[35m",
+};
 
-    // 空行且不在代码块内 → 段落结束
-    if (lines[i].trim() === "" && !inCodeBlock && i > start) {
-      // 检查从 start 到 i 是否有非空内容
-      if (lines.slice(start, i).some((l) => l.trim())) {
-        const text = lines.slice(start, i).join("\n");
-        paragraphs.push({
-          current: "",
-          incoming: text,
-          lines: [start + 1, i], // 1-based 行号
-        });
-      }
-      start = i + 1;
+function colorize(color, text) {
+  return `${colors[color]}${text}${colors.reset}`;
+}
+
+function exec(command, { debug = false } = {}) {
+  try {
+    const result = execSync(command, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return result;
+  } catch (e) {
+    if (debug) {
+      console.log(`[exec debug] cmd: ${command}`);
+      console.log(`[exec debug] stdout: ${e.stdout?.toString().trim() || "(empty)"}`);
+      console.log(`[exec debug] stderr: ${e.stderr?.toString().trim() || "(empty)"}`);
+      console.log(`[exec debug] status: ${e.status}`);
     }
+    return "";
+  }
+}
+
+// ============================================================
+// 阶段 1：Git 冲突解析（只做 git 操作）
+// ============================================================
+
+function getConflictFiles() {
+  const output = exec("git diff --name-only --diff-filter=U");
+  return output ? output.split("\n").filter((f) => f) : [];
+}
+
+// 整文件替换为 theirs（适合 lockfile 等标记损坏的文件）
+function acceptIncomingWhole(file) {
+  exec(`git checkout --theirs "${file}"`);
+}
+
+// 解析冲突标记，保留非冲突区域，冲突块取 theirs
+function resolveConflictMarkers(file) {
+  const content = readFileSync(file, "utf-8");
+  const regex = /<<<<<<<[^\n]*\r?\n([\s\S]*?)\r?\n=======\r?\n([\s\S]*?)\r?\n>>>>>>>[^\n]*/g;
+  let result = "";
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(content)) !== null) {
+    // 保留冲突块之前的非冲突内容
+    result += content.slice(lastIndex, match.index);
+    // 冲突块取 theirs
+    result += match[2];
+
+    lastIndex = match.index + match[0].length;
   }
 
-  // 最后一段
-  if (start < lines.length) {
-    const text = lines.slice(start).join("\n");
-    paragraphs.push({
-      current: "",
-      incoming: text,
-      lines: [start + 1, lines.length],
+  // 保留最后一个冲突块之后的非冲突内容
+  result += content.slice(lastIndex);
+  writeFileSync(file, result, "utf-8");
+}
+
+// 暂存文件
+function stageFile(file) {
+  console.log(colorize("green", `   - [stash] 暂存: ${file}`));
+  exec(`git add "${file}"`);
+}
+
+// 解析冲突块
+function parseConflictMarkers(file) {
+  if (!existsSync(file)) return [];
+
+  const content = readFileSync(file, "utf-8");
+  const regex = /<<<<<<<[^\n]*\r?\n([\s\S]*?)\r?\n=======\r?\n([\s\S]*?)\r?\n>>>>>>>[^\n]*/g;
+  const conflicts = [];
+  let match;
+
+  while ((match = regex.exec(content)) !== null) {
+    conflicts.push({
+      ours: match[1],
+      theirs: match[2],
+      startIndex: match.index,
+      endIndex: match.index + match[0].length,
     });
   }
 
-  return paragraphs;
+  return conflicts;
 }
 
-class GitConflictFinder {
-  constructor(replacements) {
-    this.replacements = replacements;
-    this.colors = {
-      reset: "\x1b[0m",
-      red: "\x1b[31m",
-      green: "\x1b[32m",
-      yellow: "\x1b[33m",
-      blue: "\x1b[34m",
-      cyan: "\x1b[36m",
-      magenta: "\x1b[35m",
-    };
+// 处理冲突文件：只做 git 操作，不生成翻译条目
+function handleConflictFiles() {
+  const files = getConflictFiles();
+
+  if (files.length === 0) {
+    console.log(colorize("green", "✓ 没有发现冲突文件"));
+    return;
   }
 
-  colorize(color, text) {
-    return `${this.colors[color]}${text}${this.colors.reset}`;
-  }
+  console.log(colorize("yellow", `发现 ${files.length} 个冲突文件:\n`));
 
-  exec(command) {
-    try {
-      return execSync(command, {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "ignore"],
-      }).trim();
-    } catch {
-      return "";
-    }
-  }
+  files.forEach((file) => {
+    console.log(colorize("red", `\n📄 文件: ${file}`));
 
-  getConflictFiles() {
-    const output = this.exec("git diff --name-only --diff-filter=U");
-    return output ? output.split("\n").filter((f) => f) : [];
-  }
-
-  // 整文件替换为 theirs（适合 lockfile 等标记损坏的文件）
-  acceptIncomingWhole(file) {
-    this.exec(`git checkout --theirs "${file}"`);
-  }
-
-  // 解析冲突标记，保留非冲突区域，冲突块取 theirs
-  resolveConflictMarkers(file) {
-    const content = readFileSync(file, "utf-8");
-    const regex = /<<<<<<<[^\n]*\r?\n([\s\S]*?)\r?\n=======\r?\n([\s\S]*?)\r?\n>>>>>>>[^\n]*/g;
-    let result = "";
-    let lastIndex = 0;
-    let match;
-
-    while ((match = regex.exec(content)) !== null) {
-      // 保留冲突块之前的非冲突内容
-      result += content.slice(lastIndex, match.index);
-      // 冲突块取 theirs
-      result += match[2];
-
-      lastIndex = match.index + match[0].length;
-    }
-
-    // 保留最后一个冲突块之后的非冲突内容
-    result += content.slice(lastIndex);
-    writeFileSync(file, result, "utf-8");
-  }
-
-  // 暂存文件
-  stageFile(file) {
-    console.log(this.colorize("green", `   - [stash] 暂存: ${file}`));
-    this.exec(`git add "${file}"`);
-  }
-
-  parseFile(file) {
-    if (!existsSync(file)) return [];
-
-    const content = readFileSync(file, "utf-8");
-    const regex = /<<<<<<<[^\n]*\r?\n([\s\S]*?)\r?\n=======\r?\n([\s\S]*?)\r?\n>>>>>>>[^\n]*/g;
-    const conflicts = [];
-    let match;
-
-    while ((match = regex.exec(content)) !== null) {
-      conflicts.push({
-        ours: match[1],
-        theirs: match[2],
-        startIndex: match.index,
-        endIndex: match.index + match[0].length,
-      });
-    }
-
-    return conflicts;
-  }
-
-  // ── 阶段1：检测冲突文件处理 ──
-  handleConflictFiles() {
-    const files = this.getConflictFiles();
-
-    if (files.length === 0) {
-      console.log(this.colorize("green", "✓ 没有发现冲突文件"));
-    } else {
-      console.log(this.colorize("yellow", `发现 ${files.length} 个冲突文件:\n`));
-
-      files.forEach((file) => {
-        console.log(this.colorize("red", `\n📄 文件: ${file}`));
-        // 检查是否匹配 glob 模式
-        const matchedPattern = Object.keys(DEFAULT_ACCEPT_INCOMING_LIST).find((pattern) =>
-          isGlobMatch(file, pattern),
-        );
-        if (matchedPattern) {
-          const strategy = DEFAULT_ACCEPT_INCOMING_LIST[matchedPattern];
-          if (strategy === "whole") {
-            this.acceptIncomingWhole(file);
-          } else {
-            this.resolveConflictMarkers(file);
-          }
-          console.log(
-            this.colorize("magenta", `   - [conflict] -> ${strategy} (matched: ${matchedPattern})`),
-          );
-          this.stageFile(file);
-          return;
-        }
-
-        const conflicts = this.parseFile(file);
-
-        if (conflicts.length === 0) {
-          console.log(this.colorize("cyan", `   - [无冲突] ✓ `));
-          this.stageFile(file);
-        } else {
-          /** 处理 markdown 文件冲突块 */
-          let content = readFileSync(file, "utf-8");
-
-          // 计算每个冲突在原始文件中的行号
-          const withLines = conflicts.map((c) => {
-            const startLine = content.slice(0, c.startIndex).split("\n").length; // 1-based
-            const endLine = content.slice(0, c.endIndex).split("\n").length;
-            return { ...c, startLine, endLine };
-          });
-
-          // 按行号正序，配合 offset 逐块替换
-          withLines.sort((a, b) => a.startLine - b.startLine);
-
-          const lines = content.split("\n");
-          let offset = 0;
-
-          for (const c of withLines) {
-            console.log(this.colorize("green", `\n  冲突块 #${c.startLine}:`));
-
-            const adjStart = c.startLine + offset;
-            const adjEnd = c.endLine + offset;
-            const origLen = adjEnd - adjStart + 1;
-            const theirLines = c.theirs.split("\n");
-            const newLen = theirLines.length;
-
-            lines.splice(adjStart - 1, origLen, ...theirLines);
-
-            this.replacements.push({
-              current: c.ours,
-              incoming: c.theirs,
-              file,
-              lines: [adjStart, adjStart + newLen - 1],
-            });
-
-            offset += newLen - origLen;
-          }
-
-          writeFileSync(file, lines.join("\n"), "utf-8");
-          this.stageFile(file);
-        }
-      });
-    }
-  }
-
-  // ── 阶段2：检测新增文件 ──
-  handleNewFiles() {
-    const { sync_branch, upstream_branch } = readState();
-    if (!sync_branch || !upstream_branch) {
-      console.error(this.colorize("red", "\n 无有效的同步分支或上游分支"));
-      return;
-    }
-
-    const output = this.exec(
-      `git diff --diff-filter=A --name-only ${sync_branch} ${upstream_branch} -- :(glob)src/**/*.md`,
+    // 检查是否匹配 glob 模式
+    const matchedPattern = Object.keys(DEFAULT_ACCEPT_INCOMING_LIST).find((pattern) =>
+      isGlobMatch(file, pattern),
     );
-    const newFiles = output.split("\n").filter(Boolean);
-    if (newFiles.length === 0) {
-      console.log(this.colorize("cyan", "\n📂 没有新增的 .md 文件"));
-      return;
-    }
-
-    console.log(this.colorize("yellow", `\n📂 发现 ${newFiles.length} 个新增文件:\n`));
-    for (const file of newFiles) {
-      const content = readFileSync(file, "utf-8");
-      const paragraphs = splitIntoParagraphs(content);
-
-      for (const para of paragraphs) {
-        this.replacements.push({
-          ...para,
-          file,
-        });
+    if (matchedPattern) {
+      const strategy = DEFAULT_ACCEPT_INCOMING_LIST[matchedPattern];
+      if (strategy === "whole") {
+        acceptIncomingWhole(file);
+      } else {
+        resolveConflictMarkers(file);
       }
       console.log(
-        `   ➕ ${file} (${paragraphs.length} 个段落) → 加入翻译队列`,
+        colorize("magenta", `   - [conflict] -> ${strategy} (matched: ${matchedPattern})`),
       );
-    }
-  }
-
-  // ── 阶段3：检测内容有变更的已有文件 ──
-  handleModifiedFiles() {
-    const { sync_branch, upstream_branch } = readState();
-    if (!sync_branch || !upstream_branch) {
-      console.error(this.colorize("red", "\n 无有效的同步分支或上游分支"));
+      stageFile(file);
       return;
     }
 
-    const output = this.exec(
-      `git diff --diff-filter=M --name-only ${sync_branch} ${upstream_branch} -- :(glob)src/**/*.md`,
-    );
-    const modifiedFiles = output.split("\n").filter(Boolean);
-    if (modifiedFiles.length === 0) {
-      console.log(this.colorize("cyan", "\n📝 没有修改的 .md 文件"));
+    // 普通 markdown 文件的冲突：直接用 theirs 替换冲突块
+    const conflicts = parseConflictMarkers(file);
+
+    if (conflicts.length === 0) {
+      console.log(colorize("cyan", `   - [无冲突] ✓ `));
+      stageFile(file);
       return;
     }
 
-    // 获取 merge-base，即上游上次同步的位置
-    const mergeBase = this.exec(`git merge-base ${sync_branch} ${upstream_branch}`);
-    if (!mergeBase) {
-      console.error(this.colorize("red", "\n 无法获取 merge-base"));
-      return;
+    // 计算行号，逐块替换冲突区域为 theirs
+    let content = readFileSync(file, "utf-8");
+
+    const withLines = conflicts.map((c) => {
+      const startLine = content.slice(0, c.startIndex).split("\n").length;
+      const endLine = content.slice(0, c.endIndex).split("\n").length;
+      return { ...c, startLine, endLine };
+    });
+
+    withLines.sort((a, b) => a.startLine - b.startLine);
+
+    const lines = content.split("\n");
+    let offset = 0;
+
+    for (const c of withLines) {
+      console.log(colorize("green", `  冲突块 #${c.startLine}`));
+
+      const adjStart = c.startLine + offset;
+      const adjEnd = c.endLine + offset;
+      const origLen = adjEnd - adjStart + 1;
+      const theirLines = c.theirs.replace(/\r\n/g, "\n").split("\n");
+
+      lines.splice(adjStart - 1, origLen, ...theirLines);
+      offset += theirLines.length - origLen;
     }
 
-    console.log(this.colorize("yellow", `\n📝 发现 ${modifiedFiles.length} 个修改文件 (merge-base: ${mergeBase}):\n`));
-
-    for (const file of modifiedFiles) {
-      // 对比上游英文版自身的变化（merge-base vs 当前 upstream）
-      const diffOutput = this.exec(
-        `git diff --unified=0 ${mergeBase} ${upstream_branch} -- "${file}"`,
-      );
-      if (!diffOutput) {
-        console.log(`   ⏭️  ${file} (无差异)`);
-        continue;
-      }
-
-      // 解析 hunk 头，提取上游新版本中受影响行的行号
-      const changedLines = new Set();
-      for (const line of diffOutput.split("\n")) {
-        const match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
-        if (match) {
-          const start = parseInt(match[1], 10);
-          const count = parseInt(match[2] || "1", 10);
-          for (let i = start; i < start + count; i++) {
-            changedLines.add(i);
-          }
-        }
-      }
-
-      if (changedLines.size === 0) {
-        console.log(`   ✓ ${file} (无新增行)`);
-        continue;
-      }
-
-      // 读取合并后的文件，找到包含变更行的段落
-      const mergedContent = readFileSync(file, "utf-8");
-      const paragraphs = splitIntoParagraphs(mergedContent);
-
-      const changedParas = paragraphs.filter((para) => {
-        const [pStart, pEnd] = para.lines;
-        for (let line = pStart; line <= pEnd; line++) {
-          if (changedLines.has(line)) return true;
-        }
-        return false;
-      });
-
-      if (changedParas.length > 0) {
-        for (const para of changedParas) {
-          this.replacements.push({
-            current: "",
-            incoming: para.incoming,
-            file,
-            lines: para.lines,
-          });
-        }
-        console.log(`   ✏️ ${file} (${changedParas.length} 个受影响段落) → 加入翻译队列`);
-      } else {
-        console.log(`   ✓ ${file} (段落无变化)`);
-      }
-    }
-  }
-
-  run() {
-    console.log(this.colorize("blue", "========================================"));
-    console.log(this.colorize("blue", "Vuejs 中文仓库处理 Git 冲突扫描器 (ES6 版本)"));
-    console.log(this.colorize("blue", "========================================\n"));
-
-    // ── 阶段1：既有冲突解析逻辑 ──
-    this.handleConflictFiles();
-    // ── 阶段2：处理新文件 ──
-    this.handleNewFiles();
-    // ── 阶段3：处理有变更的已有文件 ──
-    this.handleModifiedFiles();
-  }
+    writeFileSync(file, lines.join("\n"), "utf-8");
+    stageFile(file);
+  });
 }
 
-export function resolveConflicts() {
+// ============================================================
+// 阶段 2：冲突解决后，通过 git diff --cached 生成翻译队列
+// ============================================================
+
+// 解析 unified diff（--unified=0），提取每个 hunk 的旧/新内容
+// 返回 { current, incoming, lines }[]
+function parseDiffHunks(diffOutput) {
+  const entries = [];
+  let cur = null;
+
+  for (const line of diffOutput.split("\n")) {
+    const m = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (m) {
+      if (cur) {
+        cur.current = cur.oldLines.join("\n");
+        cur.incoming = cur.newLines.join("\n");
+        cur.lines = [cur.newStart, cur.newStart + cur.newCount - 1];
+        entries.push({ current: cur.current, incoming: cur.incoming, lines: cur.lines });
+      }
+      cur = { newStart: parseInt(m[3], 10), newCount: parseInt(m[4] || "1", 10), oldLines: [], newLines: [] };
+      continue;
+    }
+    if (!cur) continue;
+    if (line.startsWith("-")) cur.oldLines.push(line.slice(1));
+    else if (line.startsWith("+")) cur.newLines.push(line.slice(1));
+  }
+  if (cur) {
+    entries.push({
+      current: cur.oldLines.join("\n"),
+      incoming: cur.newLines.join("\n"),
+      lines: [cur.newStart, cur.newStart + cur.newCount - 1],
+    });
+  }
+
+  return entries;
+}
+
+function generateTodo() {
+  const stagedOutput = exec(
+    `git diff --cached --name-only --diff-filter=AM -- ":(glob)src/**/*.md"`,
+  );
+  const stagedFiles = stagedOutput.split("\n").filter(Boolean);
+
+  if (stagedFiles.length === 0) {
+    console.log(colorize("cyan", "\n没有需要翻译的文件"));
+    return [];
+  }
+
+  console.log(colorize("yellow", `\n发现 ${stagedFiles.length} 个待处理文件:\n`));
+
   const replacements = [];
-  const finder = new GitConflictFinder(replacements);
-  finder.run();
+  let lastFile = "";
+
+  for (const file of stagedFiles) {
+    const entries = parseDiffHunks(
+      exec(`git diff --cached --unified=0 -- "${file}"`),
+    );
+    if (entries.length === 0) {
+      if (file !== lastFile) console.log(`   ✓ ${file}`);
+      continue;
+    }
+
+    // 跳过纯删除（newCount=0）和无变更（old===new）的 hunk
+    const todo = entries.filter((e) => e.lines[0] <= e.lines[1] && e.current !== e.incoming);
+    if (todo.length === 0) {
+      if (file !== lastFile) console.log(`   ✓ ${file}`);
+      continue;
+    }
+
+    for (const entry of todo) {
+      replacements.push({ ...entry, file });
+    }
+    console.log(`   ✏️ ${file} (${todo.length} 处变更)`);
+    lastFile = file;
+  }
+
+  return replacements;
+}
+
+// ============================================================
+// 入口：先解决冲突，再生成翻译队列
+// ============================================================
+
+export function resolveConflicts() {
+  console.log(colorize("blue", "========================================"));
+  console.log(colorize("blue", "Vuejs 中文仓库 Git 冲突扫描器"));
+  console.log(colorize("blue", "========================================\n"));
+
+  // 步骤 1：处理 git 冲突（只做 git 操作）
+  handleConflictFiles();
+
+  // 步骤 2：git diff --cached 对比 HEAD vs staged，生成 todo
+  console.log(colorize("blue", "\n--- 检测变更，生成翻译队列 ---"));
+  const replacements = generateTodo();
 
   // 过滤掉被 ignore_globs 排除的文件
   const { ignore_globs } = readState();
@@ -381,6 +305,10 @@ export function resolveConflicts() {
       const excludedCount = replacements.length - filtered.length;
       console.log(`共排除 ${excludedFiles.length} 个文件（${excludedCount} 个条目）\n`);
     }
+  }
+
+  if (filtered.length > 0) {
+    console.log(colorize("cyan", `\n总共 ${filtered.length} 个待翻译条目\n`));
   }
 
   writeFileSync(


### PR DESCRIPTION
### 在创建 pull request 之前

请确认：

- [x] 我已经阅读过项目的 [wiki](https://github.com/vuejs-translations/docs-zh-cn/wiki) 了解相关注意事项。
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[英文文档仓库](https://github.com/vuejs/docs)讨论，相关结论会被定期从英文版同步)

### 变更内容                                                                                                                                                                                                            
1. `resolve-conflicts.js` 重构                                                                                                                                                                                        
                                                                                                                                                                                                                      
  - 将 GitConflictFinder 类拆分为阶段式函数，分为 Git 冲突解析 和 冲突处理 两个阶段
  - 移除 `splitIntoParagraphs` 段落拆分逻辑，简化架构
  - 提取通用工具函数（colorize、exec），减少代码重复
  - 整体净减约 70 行代码

  2. IGNORE_GLOBS 支持

  - 新增 isFileIgnored 过滤功能，匹配 ignore_globs 配置的文件将排除在 AI 翻译队列之外
  - Stage 阶段在控制台打印被忽略的文件清单，方便排查
  - PR body 中自动列出因 IGNORE_GLOBS 跳过的文件

  3. 已有同步 PR 时的行为优化

  - 当检测到已有同步 PR 时，不再直接 return 跳过整个 pipeline
  - 改为先生成 `todo-translation.json`，仅跳过 AI 翻译阶段
  - 避免因 Review 周期长导致冲突积累，下次 sync 时可直接基于已有记录继续

  4. CRLF 行尾处理

  - `apply-translations.js` 在读取文件时增加 `\r\n → \n 转换`，避免 Windows 环境下行号偏差

  5. 其他改进

  - Cleanup 阶段增加对 STATE_PATH 的清理
  - Prepare 阶段创建本地 upstream 分支引用，修复后续 `git diff/merge-base` 的依赖
  - 调整 state 写入顺序（在 resolveConflicts 之前写入），确保 ignore_globs 等信息正确传递
  - PR body 增加 CREATED_PR=false 时的跳过日志

### Github Actions

- [查看这个 job](https://github.com/vuejs-translations/docs-zh-cn/actions/runs/29265143108/job/86868292881)
- 此 PR，合并后，仍需合并到 sync 分支，不勾选 PR 情况下，跑一次 actions，查看 log 是否如何预期